### PR TITLE
Remove the LocalQVMCompiler from the tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyquil>=2.3
+pyquil>=2.4
 pennylane>=0.2
 networkx

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("pennylane_forest/_version.py") as f:
 
 
 requirements = [
-    "pyquil>=2.3",
+    "pyquil>=2.4",
     "pennylane>=0.2"
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from scipy.linalg import expm, block_diag
 
 from pyquil import get_qc, Program
 from pyquil.gates import I as Id
-from pyquil.api import QVMConnection, LocalQVMCompiler, local_qvm
+from pyquil.api import QVMConnection, QVMCompiler, local_qvm
 from pyquil.api._config import PyquilConfig
 from pyquil.api._errors import UnknownApiError
 
@@ -139,7 +139,7 @@ def compiler():
     try:
         config = PyquilConfig()
         device = get_qc('3q-qvm').device
-        compiler = LocalQVMCompiler(endpoint=config.compiler_url, device=device)
+        compiler = QVMCompiler(endpoint=config.compiler_url, device=device)
         compiler.quil_to_native_quil(Program(Id(0)))
         return compiler
     except (RequestException, UnknownApiError, TypeError) as e:


### PR DESCRIPTION
This pull request removes the `LocalQVMCompiler` from the tests, as this class has been deprecated from PyQuil 2.4 in favor of a unified `QVMCompiler`.

At the same time, the PyQuil requirement has been updated to version 2.4 in both `requirements.py` and `setup.py`.