### PR TITLE
Added support for pyQVM

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Contains the PennyLane Forest plugin. This plugin allows three Rigetti devices t
 Features
 ========
 
-* Provides four devices to be used with PennyLane: ``forest.numpy``, ``forest.wavefunction``, ``forest.qvm``, and ``forest.qpu``. These provide access to the pyQVM Numpy wavefunction simulator, Forest wavefunction simulator, quantum virtual machine (QVM), and quantum processing unit (QPU) respectively.
+* Provides four devices to be used with PennyLane: ``forest.numpy_wavefunction``, ``forest.wavefunction``, ``forest.qvm``, and ``forest.qpu``. These provide access to the pyQVM Numpy wavefunction simulator, Forest wavefunction simulator, quantum virtual machine (QVM), and quantum processing unit (QPU) respectively.
 
 
 * All provided devices support all core qubit PennyLane operations and expectation values.
@@ -50,7 +50,7 @@ You can instantiate these devices for PennyLane as follows:
 .. code-block:: python
 
     import pennylane as qml
-    dev_numpy = qml.device('forest.numpy', wires=2)
+    dev_numpy = qml.device('forest.numpy_wavefunction', wires=2)
     dev_simulator = qml.device('forest.wavefunction', wires=2)
     dev_pyqvm = qml.device('forest.qvm', device='2q-pyqvm', shots=1000)
     dev_qvm = qml.device('forest.qvm', device='2q-qvm', shots=1000)

--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,11 @@ Contains the PennyLane Forest plugin. This plugin allows three Rigetti devices t
 Features
 ========
 
-* Provides three devices to be used with PennyLane: ``forest.wavefunction``, ``forest.qvm``, and ``forest.qpu``. These provide access to the Forest wavefunction simulator, quantum virtual machine (QVM), and quantum processing unit (QPU) respectively.
+* Provides four devices to be used with PennyLane: ``forest.numpy``, ``forest.wavefunction``, ``forest.qvm``, and ``forest.qpu``. These provide access to the pyQVM Numpy wavefunction simulator, Forest wavefunction simulator, quantum virtual machine (QVM), and quantum processing unit (QPU) respectively.
 
-* All provided devices support all core qubit PennyLane operations.
 
-* In addition, ``forest.wavefunction`` supports all core qubit PennyLane expectation values. ``forest.qvm`` and ``forest.qpu`` only support ``PauliZ`` expectation values.
+* All provided devices support all core qubit PennyLane operations and expectation values.
+
 
 * Provides custom PennyLane operations to cover additional pyQuil operations: ``T``, ``S``, ``ISWAP``, ``CCNOT``, ``PSWAP``, and many more. Every custom operation supports analytic differentiation.
 
@@ -43,8 +43,10 @@ You can instantiate these devices for PennyLane as follows:
 .. code-block:: python
 
     import pennylane as qml
+    dev_numpy = qml.device('forest.numpy', wires=2)
     dev_simulator = qml.device('forest.wavefunction', wires=2)
-    dev_qvm = qml.device('forest.qvm', device='2q-qvm', wires=2, shots=1000)
+    dev_pyqvm = qml.device('forest.qvm', device='2q-pyqvm', shots=1000)
+    dev_qvm = qml.device('forest.qvm', device='2q-qvm', shots=1000)
     dev_qpu = qml.device('forest.qpu', device='Aspen-0-12Q-A', shots=1000)
 
 These devices can then be used just like other devices for the definition and evaluation of QNodes within PennyLane. For more details, see the `plugin usage guide <https://pennylane-forest.readthedocs.io/en/latest/usage.html>`_ and refer to the PennyLane documentation.

--- a/doc/code/numpy_wavefunction.rst
+++ b/doc/code/numpy_wavefunction.rst
@@ -1,0 +1,4 @@
+.. automodule:: pennylane_forest.numpy_wavefunction
+   :members:
+   :private-members:
+   :special-members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,7 +16,7 @@ This PennyLane plugin allows the Rigetti Forest and pyQuil simulators to be used
 Features
 ========
 
-* Provides four devices to be used with PennyLane: ``forest.numpy``, ``forest.wavefunction``, ``forest.qvm``, and ``forest.qpu``. These provide access to the pyQVM Numpy wavefunction simulator, Forest wavefunction simulator, quantum virtual machine (QVM), and quantum processing unit (QPU) respectively.
+* Provides four devices to be used with PennyLane: ``forest.numpy_wavefunction``, ``forest.wavefunction``, ``forest.qvm``, and ``forest.qpu``. These provide access to the pyQVM Numpy wavefunction simulator, Forest wavefunction simulator, quantum virtual machine (QVM), and quantum processing unit (QPU) respectively.
 
 
 * All provided devices support all core qubit PennyLane operations and expectation values.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -16,13 +16,10 @@ This PennyLane plugin allows the Rigetti Forest and pyQuil simulators to be used
 Features
 ========
 
-* Provides three devices to be used with PennyLane: ``forest.wavefunction``, ``forest.qvm``, and ``forest.qpu``. These provide access to the Forest wavefunction simulator, quantum virtual machine (QVM), and quantum processing unit (QPU) respectively.
+* Provides four devices to be used with PennyLane: ``forest.numpy``, ``forest.wavefunction``, ``forest.qvm``, and ``forest.qpu``. These provide access to the pyQVM Numpy wavefunction simulator, Forest wavefunction simulator, quantum virtual machine (QVM), and quantum processing unit (QPU) respectively.
 
 
-* All provided devices support all core qubit PennyLane operations.
-
-
-* In addition, ``forest.wavefunction`` supports all core qubit PennyLane expectation values. ``forest.qvm`` and ``forest.qpu`` only support ``PauliZ`` expectation values.
+* All provided devices support all core qubit PennyLane operations and expectation values.
 
 
 * Provides custom PennyLane operations to cover additional pyQuil operations: ``T``, ``S``, ``ISWAP``, ``CCNOT``, ``PSWAP``, and many more. Every custom operation supports analytic differentiation.
@@ -58,6 +55,7 @@ Contents
 
    code/ops
    code/device
+   code/numpy_wavefunction
    code/wavefunction
    code/qvm
    code/qpu

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -5,7 +5,7 @@ Plugin usage
 
 PennyLane-Forest provides four Forest devices for PennyLane:
 
-* :class:`forest.numpy <~NumpyWavefunctionDevice>`: provides a PennyLane device for the pyQVM Numpy wavefunction simulator
+* :class:`forest.numpy_wavefunction <~NumpyWavefunctionDevice>`: provides a PennyLane device for the pyQVM Numpy wavefunction simulator
 
 * :class:`forest.wavefunction <~WavefunctionDevice>`: provides a PennyLane device for the Forest wavefunction simulator
 
@@ -22,7 +22,7 @@ Once PyQuil and the PennyLane plugin are installed, the three Forest devices can
 You can instantiate these devices in PennyLane as follows:
 
 >>> import pennylane as qml
->>> dev_numpy = qml.device('forest.numpy', wires=2)
+>>> dev_numpy = qml.device('forest.numpy_wavefunction', wires=2)
 >>> dev_simulator = qml.device('forest.wavefunction', wires=2)
 >>> dev_pyqvm = qml.device('forest.qvm', device='2q-pyqvm', shots=1000)
 >>> dev_qvm = qml.device('forest.qvm', device='2q-qvm', shots=1000)
@@ -121,10 +121,10 @@ On initialization, the PennyLane-Forest devices accept additional keyword argume
     the input/output of the compiler to protoquil.
 
 
-The ``forest.numpy`` device
-===========================
+The ``forest.numpy_wavefunction`` device
+========================================
 
-The ``forest.numpy`` device provides an interface between PennyLane and the pyQuil `NumPy wavefunction simulator <http://docs.rigetti.com/en/stable/wavefunction_simulator.html>`_. Because the NumPy wavefunction simulator allows access and manipulation of the underlying quantum state vector, ``forest.numpy`` is able to support the full suite of PennyLane and Quil quantum operations and expectation values.
+The ``forest.numpy_wavefunction`` device provides an interface between PennyLane and the pyQuil `NumPy wavefunction simulator <http://docs.rigetti.com/en/stable/wavefunction_simulator.html>`_. Because the NumPy wavefunction simulator allows access and manipulation of the underlying quantum state vector, ``forest.numpy_wavefunction`` is able to support the full suite of PennyLane and Quil quantum operations and expectation values.
 
 In addition, it is generally faster than running equivalent simulations on the QVM, as the final state can be inspected and the expectation value calculated analytically, rather than by sampling measurements.
 
@@ -137,12 +137,12 @@ In addition, it is generally faster than running equivalent simulations on the Q
 
 .. note::
 
-    By default, ``forest.numpy`` is initialized with ``shots=0``, indicating
+    By default, ``forest.numpy_wavefunction`` is initialized with ``shots=0``, indicating
     that the exact analytic expectation value is to be returned.
 
-    If the number of trials or shots provided to the ``forest.numpy`` is
+    If the number of trials or shots provided to the ``forest.numpy_wavefunction`` is
     instead non-zero, a spectral decomposition is performed and a Bernoulli distribution
-    is constructed and sampled. This allows the ``forest.numpy`` device to
+    is constructed and sampled. This allows the ``forest.numpy_wavefunction`` device to
     'approximate' the effect of sampling the expectation value.
 
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -114,12 +114,6 @@ On initialization, the PennyLane-Forest devices accept additional keyword argume
     on a provided QMI, these environment variables are set automatically and will also
     not need to be passed in PennyLane.
 
-.. note::
-
-    If using the pyQuil built-in pyQVM, you will still need to have an accessible Forest Quil compiler
-    server. This must be launched with the command ``quilc -S -P``, where the ``-P`` flag restricts
-    the input/output of the compiler to protoquil.
-
 
 The ``forest.numpy_wavefunction`` device
 ========================================

--- a/pennylane_forest/__init__.py
+++ b/pennylane_forest/__init__.py
@@ -6,4 +6,5 @@ from .ops import (S, T, CCNOT, CPHASE, CSWAP, ISWAP, PSWAP)
 from .qpu import QPUDevice
 from .qvm import QVMDevice
 from .wavefunction import WavefunctionDevice
+from .numpy_wavefunction import NumpyWavefunctionDevice
 from ._version import __version__

--- a/pennylane_forest/_version.py
+++ b/pennylane_forest/_version.py
@@ -2,4 +2,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -234,7 +234,7 @@ class ForestDevice(Device):
             self.active_wires = set(range(self.num_wires))
 
     @abc.abstractmethod
-    def pre_expval(self):
+    def pre_expval(self): #pragma no cover
         """Run the QVM or QPU"""
         raise NotImplementedError
 

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -38,7 +38,7 @@ class NumpyWavefunctionDevice(ForestDevice):
             to estimate expectation values of expectations.
     """
     name = 'pyQVM NumpyWavefunction Simulator Device'
-    short_name = 'forest.numpy'
+    short_name = 'forest.numpy_wavefunction'
 
     expectations = {'PauliX', 'PauliY', 'PauliZ', 'Hadamard', 'Hermitian', 'Identity'}
 
@@ -52,6 +52,11 @@ class NumpyWavefunctionDevice(ForestDevice):
         self.qc.wf_simulator.reset()
 
     def pre_expval(self):
+        # TODO: currently, the PyQVM considers qubit 0 as the leftmost bit and therefore
+        # returns amplitudes in the opposite of the Rigetti Lisp QVM (which considers qubit
+        # 0 as the rightmost bit). This may change in the future, so in the future this
+        # might need to get udpated to be similar to the pre_expval function of
+        #pennylane_forest/wavefunction.py
         self.state = self.qc.execute(self.prog).wf_simulator.wf.flatten()
 
     def expval(self, expectation, wires, par):

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -1,0 +1,109 @@
+"""
+NumpyWavefunction simulator device
+==================================
+
+**Module name:** :mod:`pennylane_forest.numpy_wavefunction`
+
+.. currentmodule:: pennylane_forest.numpy_wavefunction
+
+This module contains the :class:`~.NumpyWavefunctionDevice` class, a PennyLane device that allows
+evaluation and differentiation of pyQuil's NumpyWavefunctionSimulator using PennyLane.
+
+
+Classes
+-------
+
+.. autosummary::
+   NumpyWavefunctionDevice
+
+Code details
+~~~~~~~~~~~~
+"""
+import numpy as np
+
+from pyquil.pyqvm import PyQVM
+from pyquil.numpy_simulator import NumpyWavefunctionSimulator
+
+from .device import ForestDevice
+from .wavefunction import expectation_map, spectral_decomposition_qubit
+from ._version import __version__
+
+
+class NumpyWavefunctionDevice(ForestDevice):
+    r"""NumpyWavefunction simulator device for PennyLane.
+
+    Args:
+        wires (int): the number of qubits to initialize the device in
+        shots (int): Number of circuit evaluations/random samples used
+            to estimate expectation values of expectations.
+    """
+    name = 'pyQVM NumpyWavefunction Simulator Device'
+    short_name = 'forest.numpy'
+
+    expectations = {'PauliX', 'PauliY', 'PauliZ', 'Hadamard', 'Hermitian', 'Identity'}
+
+    def __init__(self, wires, *, shots=0, **kwargs):
+        super().__init__(wires, shots, **kwargs)
+        self.qc = PyQVM(n_qubits=wires, quantum_simulator_type=NumpyWavefunctionSimulator)
+        self.state = None
+
+    def pre_apply(self):
+        self.reset()
+        self.qc.wf_simulator.reset()
+
+    def pre_expval(self):
+        self.state = self.qc.execute(self.prog).wf_simulator.wf.flatten()
+
+    def expval(self, expectation, wires, par):
+        # measurement/expectation value <psi|A|psi>
+        if expectation == 'Hermitian':
+            A = par[0]
+        else:
+            A = expectation_map[expectation]
+
+        if self.shots == 0:
+            # exact expectation value
+            ev = self.ev(A, wires)
+        else:
+            # estimate the ev
+            # sample Bernoulli distribution n_eval times / binomial distribution once
+            a, P = spectral_decomposition_qubit(A)
+            p0 = self.ev(P[0], wires)  # probability of measuring a[0]
+            n0 = np.random.binomial(self.shots, p0)
+            ev = (n0*a[0] +(self.shots-n0)*a[1]) / self.shots
+
+        return ev
+
+    def ev(self, A, wires):
+        r"""Evaluates a one-qubit expectation in the current state.
+
+        Args:
+          A (array): :math:`2\times 2` Hermitian matrix corresponding to the expectation
+          wires (Sequence[int]): target subsystem
+
+        Returns:
+          float: expectation value :math:`\left\langle{A}\right\rangle = \left\langle{\psi}\mid A\mid{\psi}\right\rangle`
+        """
+        # Expand the Hermitian observable over the entire subsystem
+        A = self.expand_one(A, wires)
+        return np.vdot(self.state, A @ self.state).real
+
+    def expand_one(self, U, wires):
+        r"""Expand a one-qubit operator into a full system operator.
+
+        Args:
+          U (array): :math:`2\times 2` matrix
+          wires (Sequence[int]): target subsystem
+
+        Returns:
+          array: :math:`2^n\times 2^n` matrix
+        """
+        if U.shape != (2, 2):
+            raise ValueError('2x2 matrix required.')
+        if len(wires) != 1:
+            raise ValueError('One target subsystem required.')
+        wires = wires[0]
+        before = 2**wires
+        after = 2**(self.num_wires-wires-1)
+        U = np.kron(np.kron(np.eye(before), U), np.eye(after))
+        return U

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -158,9 +158,13 @@ class QVMDevice(ForestDevice):
             self.prog.inst(MEASURE(q, ro[i]))
 
         self.prog.wrap_in_numshots_loop(self.shots)
-        executable = self.qc.compile(self.prog)
 
-        bitstring_array = self.qc.run(executable=executable)
+        if "pyqvm" in self.qc.name:
+            bitstring_array = self.qc.run(self.prog)
+        else:
+            executable = self.qc.compile(self.prog)
+            bitstring_array = self.qc.run(executable=executable)
+
         self.state = {}
         for i, q in enumerate(qubits):
             self.state[q] = bitstring_array[:, i]

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -35,11 +35,17 @@ from ._version import __version__
 class QVMDevice(ForestDevice):
     r"""Forest QVM device for PennyLane.
 
+    This device supports both the Rigetti Lisp QVM, as well as the built-in pyQuil pyQVM.
+    If using the pyQVM, the ``qvm_url`` QVM server url keyword argument does not need to
+    be set.
+
     Args:
         device (Union[str, nx.Graph]): the name or topology of the device to initialise.
 
             * ``Nq-qvm``: for a fully connected/unrestricted N-qubit QVM
             * ``9q-qvm-square``: a :math:`9\times 9` lattice.
+            * ``Nq-pyqvm`` or ``9q-pyqvm-square``, for the same as the above but run
+              via the built-in pyQuil pyQVM device.
             * Any other supported Rigetti device architecture.
             * Graph topology representing the device architecture.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyquil>=2.3
+pyquil>=2.4
 pennylane>=0.2
 networkx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyquil>=2.4
+pyquil>=2.3
 pennylane>=0.2
 networkx

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("pennylane_forest/_version.py") as f:
 
 
 requirements = [
-    "pyquil>=2.4",
+    "pyquil>=2.3",
     "pennylane>=0.2"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Operating System :: MacOS :: MacOS X",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("pennylane_forest/_version.py") as f:
 
 
 requirements = [
-    "pyquil>=2.3",
+    "pyquil>=2.4",
     "pennylane>=0.2"
 ]
 
@@ -27,6 +27,7 @@ info = {
             'forest.qpu = pennylane_forest:QPUDevice',
             'forest.qvm = pennylane_forest:QVMDevice',
             'forest.wavefunction = pennylane_forest:WavefunctionDevice',
+            'forest.numpy = pennylane_forest:NumpyWavefunctionDevice'
             ],
         },
     'description': 'Rigetti backend for the PennyLane library',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ info = {
             'forest.qpu = pennylane_forest:QPUDevice',
             'forest.qvm = pennylane_forest:QVMDevice',
             'forest.wavefunction = pennylane_forest:WavefunctionDevice',
-            'forest.numpy = pennylane_forest:NumpyWavefunctionDevice'
+            'forest.numpy_wavefunction = pennylane_forest:NumpyWavefunctionDevice'
             ],
         },
     'description': 'Rigetti backend for the PennyLane library',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from scipy.linalg import expm, block_diag
 
 from pyquil import get_qc, Program
 from pyquil.gates import I as Id
-from pyquil.api import QVMConnection, QVMCompiler, local_qvm
+from pyquil.api import QVMConnection, LocalQVMCompiler, local_qvm
 from pyquil.api._config import PyquilConfig
 from pyquil.api._errors import UnknownApiError
 
@@ -139,7 +139,7 @@ def compiler():
     try:
         config = PyquilConfig()
         device = get_qc('3q-qvm').device
-        compiler = QVMCompiler(endpoint=config.compiler_url, device=device)
+        compiler = LocalQVMCompiler(endpoint=config.compiler_url, device=device)
         compiler.quil_to_native_quil(Program(Id(0)))
         return compiler
     except (RequestException, UnknownApiError, TypeError) as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from scipy.linalg import expm, block_diag
 
 from pyquil import get_qc, Program
 from pyquil.gates import I as Id
-from pyquil.api import QVMConnection, LocalQVMCompiler, local_qvm
+from pyquil.api import QVMConnection, QVMCompiler, local_qvm
 from pyquil.api._config import PyquilConfig
 from pyquil.api._errors import UnknownApiError
 
@@ -139,7 +139,7 @@ def compiler():
     try:
         config = PyquilConfig()
         device = get_qc('3q-qvm').device
-        compiler = LocalQVMCompiler(endpoint=config.compiler_url, device=device)
+        compiler = QVMCompiler(endpoint=config.compiler_url, device=device)
         compiler.quil_to_native_quil(Program(Id(0)))
         return compiler
     except (RequestException, UnknownApiError, TypeError) as e:

--- a/tests/test_numpy_wavefunction.py
+++ b/tests/test_numpy_wavefunction.py
@@ -124,14 +124,14 @@ class TestWavefunctionIntegration(BaseTest):
 
     def test_load_wavefunction_device(self):
         """Test that the wavefunction device loads correctly"""
-        dev = qml.device('forest.numpy', wires=2)
+        dev = qml.device('forest.numpy_wavefunction', wires=2)
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.shots, 0)
-        self.assertEqual(dev.short_name, 'forest.numpy')
+        self.assertEqual(dev.short_name, 'forest.numpy_wavefunction')
 
     def test_program_property(self):
         """Test that the program property works as expected"""
-        dev = qml.device('forest.numpy', wires=2)
+        dev = qml.device('forest.numpy_wavefunction', wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -150,11 +150,11 @@ class TestWavefunctionIntegration(BaseTest):
     def test_wavefunction_args(self):
         """Test that the wavefunction plugin requires correct arguments"""
         with pytest.raises(TypeError, message="missing 1 required positional argument: 'wires'"):
-            qml.device('forest.numpy')
+            qml.device('forest.numpy_wavefunction')
 
     def test_hermitian_expectation(self, tol):
         """Test that an arbitrary Hermitian expectation value works"""
-        dev = qml.device('forest.numpy', wires=1)
+        dev = qml.device('forest.numpy_wavefunction', wires=1)
 
         @qml.qnode(dev)
         def circuit():
@@ -168,7 +168,7 @@ class TestWavefunctionIntegration(BaseTest):
 
     def test_qubit_unitary(self, tol):
         """Test that an arbitrary unitary operation works"""
-        dev = qml.device('forest.numpy', wires=3)
+        dev = qml.device('forest.numpy_wavefunction', wires=3)
 
         @qml.qnode(dev)
         def circuit():
@@ -184,7 +184,7 @@ class TestWavefunctionIntegration(BaseTest):
 
     def test_invalid_qubit_unitary(self):
         """Test that an invalid unitary operation is not allowed"""
-        dev = qml.device('forest.numpy', wires=3)
+        dev = qml.device('forest.numpy_wavefunction', wires=3)
 
         def circuit(Umat):
             """Test QNode"""
@@ -205,7 +205,7 @@ class TestWavefunctionIntegration(BaseTest):
 
     def test_one_qubit_wavefunction_circuit(self, tol):
         """Test that the wavefunction plugin provides correct result for simple circuit"""
-        dev = qml.device('forest.numpy', wires=1)
+        dev = qml.device('forest.numpy_wavefunction', wires=1)
 
         a = 0.543
         b = 0.123
@@ -225,7 +225,7 @@ class TestWavefunctionIntegration(BaseTest):
     def test_two_qubit_wavefunction_circuit(self, tol):
         """Test that the wavefunction plugin provides correct result for simple 2-qubit circuit,
         even when the number of wires > number of qubits."""
-        dev = qml.device('forest.numpy', wires=3)
+        dev = qml.device('forest.numpy_wavefunction', wires=3)
 
         a = 0.543
         b = 0.123
@@ -248,7 +248,7 @@ class TestWavefunctionIntegration(BaseTest):
     def test_nonzero_shots(self):
         """Test that the wavefunction plugin provides correct result for high shot number"""
         shots = 10**2
-        dev = qml.device('forest.numpy', wires=1, shots=shots)
+        dev = qml.device('forest.numpy_wavefunction', wires=1, shots=shots)
 
         a = 0.543
         b = 0.123

--- a/tests/test_numpy_wavefunction.py
+++ b/tests/test_numpy_wavefunction.py
@@ -12,45 +12,17 @@ from conftest import BaseTest
 from conftest import I, U, U2, H, test_operation_map
 
 import pennylane_forest as plf
-from pennylane_forest.wavefunction import spectral_decomposition_qubit
 
 
 log = logging.getLogger(__name__)
 
 
-class TestAuxillaryFunctions(BaseTest):
-    """Test auxillary functions."""
-
-    def test_spectral_decomposition_qubit(self, tol):
-        """Test that the correct spectral decomposition is returned."""
-        a, P = spectral_decomposition_qubit(H)
-
-        # verify that H = \sum_k a_k P_k
-        self.assertAllAlmostEqual(H, np.einsum('i,ijk->jk', a, P), delta=tol)
-
-
 class TestWavefunctionBasic(BaseTest):
-    """Unit tests for the wavefunction simulator."""
-
-    def test_expand_state(self):
-        """Test that a multi-qubit state is correctly expanded for a N-qubit device"""
-        dev = plf.WavefunctionDevice(wires=3)
-
-        # expand a two qubit state to the 3 qubit device
-        dev.state = np.array([0, 1, 1, 0])/np.sqrt(2)
-        dev.active_wires = {0, 2}
-        dev.expand_state()
-        self.assertAllEqual(dev.state, np.array([0, 1, 0, 0, 1, 0, 0, 0])/np.sqrt(2))
-
-        # expand a three qubit state to the 3 qubit device
-        dev.state = np.array([0, 1, 1, 0, 0, 1, 1, 0])/2
-        dev.active_wires = {0, 1, 2}
-        dev.expand_state()
-        self.assertAllEqual(dev.state, np.array([0, 1, 1, 0, 0, 1, 1, 0])/2)
+    """Unit tests for the NumPy wavefunction simulator."""
 
     def test_expand_one(self, tol):
         """Test that a 1 qubit gate correctly expands to 3 qubits."""
-        dev = plf.WavefunctionDevice(wires=3)
+        dev = plf.NumpyWavefunctionDevice(wires=3)
 
         # test applied to wire 0
         res = dev.expand_one(U, [0])
@@ -75,10 +47,10 @@ class TestWavefunctionBasic(BaseTest):
         with pytest.raises(ValueError, message="One target subsystem required"):
             dev.expand_one(U, [0, 1])
 
-    @pytest.mark.parametrize("ev", plf.WavefunctionDevice.expectations)
+    @pytest.mark.parametrize("ev", plf.NumpyWavefunctionDevice.expectations)
     def test_ev(self, ev, tol):
         """Test that expectation values are calculated correctly"""
-        dev = plf.WavefunctionDevice(wires=2)
+        dev = plf.NumpyWavefunctionDevice(wires=2)
 
         # start in the following initial state
         dev.state = np.array([1, 0, 1, 1])/np.sqrt(3)
@@ -100,10 +72,10 @@ class TestWavefunctionBasic(BaseTest):
         # verify the device is now in the expected state
         self.assertAllAlmostEqual(res, expected_out, delta=tol)
 
-    @pytest.mark.parametrize("gate", plf.WavefunctionDevice._operation_map) #pylint: disable=protected-access
-    def test_apply(self, gate, apply_unitary, tol, qvm, compiler):
+    @pytest.mark.parametrize("gate", plf.NumpyWavefunctionDevice._operation_map) #pylint: disable=protected-access
+    def test_apply(self, gate, apply_unitary, tol):
         """Test the application of gates to a state"""
-        dev = plf.WavefunctionDevice(wires=3)
+        dev = plf.NumpyWavefunctionDevice(wires=3)
 
         try:
             # get the equivalent pennylane operation class
@@ -147,19 +119,19 @@ class TestWavefunctionBasic(BaseTest):
 
 
 class TestWavefunctionIntegration(BaseTest):
-    """Test the wavefunction simulator works correctly from the PennyLane frontend."""
+    """Test the NumPy wavefunction simulator works correctly from the PennyLane frontend."""
     # pylint:disable=no-self-use
 
     def test_load_wavefunction_device(self):
         """Test that the wavefunction device loads correctly"""
-        dev = qml.device('forest.wavefunction', wires=2)
+        dev = qml.device('forest.numpy', wires=2)
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.shots, 0)
-        self.assertEqual(dev.short_name, 'forest.wavefunction')
+        self.assertEqual(dev.short_name, 'forest.numpy')
 
-    def test_program_property(self, qvm, compiler):
+    def test_program_property(self):
         """Test that the program property works as expected"""
-        dev = qml.device('forest.wavefunction', wires=2)
+        dev = qml.device('forest.numpy', wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -178,11 +150,11 @@ class TestWavefunctionIntegration(BaseTest):
     def test_wavefunction_args(self):
         """Test that the wavefunction plugin requires correct arguments"""
         with pytest.raises(TypeError, message="missing 1 required positional argument: 'wires'"):
-            qml.device('forest.wavefunction')
+            qml.device('forest.numpy')
 
-    def test_hermitian_expectation(self, tol, qvm, compiler):
+    def test_hermitian_expectation(self, tol):
         """Test that an arbitrary Hermitian expectation value works"""
-        dev = qml.device('forest.wavefunction', wires=1)
+        dev = qml.device('forest.numpy', wires=1)
 
         @qml.qnode(dev)
         def circuit():
@@ -194,9 +166,9 @@ class TestWavefunctionIntegration(BaseTest):
         out_state = 1j*np.array([-1, 1])/np.sqrt(2)
         self.assertAllAlmostEqual(circuit(), np.vdot(out_state, H @ out_state), delta=tol)
 
-    def test_qubit_unitary(self, tol, qvm, compiler):
+    def test_qubit_unitary(self, tol):
         """Test that an arbitrary unitary operation works"""
-        dev = qml.device('forest.wavefunction', wires=3)
+        dev = qml.device('forest.numpy', wires=3)
 
         @qml.qnode(dev)
         def circuit():
@@ -212,7 +184,7 @@ class TestWavefunctionIntegration(BaseTest):
 
     def test_invalid_qubit_unitary(self):
         """Test that an invalid unitary operation is not allowed"""
-        dev = qml.device('forest.wavefunction', wires=3)
+        dev = qml.device('forest.numpy', wires=3)
 
         def circuit(Umat):
             """Test QNode"""
@@ -231,9 +203,9 @@ class TestWavefunctionIntegration(BaseTest):
         with pytest.raises(ValueError, message=r"must be 2\^Nx2\^N"):
             circuit1(U)
 
-    def test_one_qubit_wavefunction_circuit(self, tol, qvm, compiler):
+    def test_one_qubit_wavefunction_circuit(self, tol):
         """Test that the wavefunction plugin provides correct result for simple circuit"""
-        dev = qml.device('forest.wavefunction', wires=1)
+        dev = qml.device('forest.numpy', wires=1)
 
         a = 0.543
         b = 0.123
@@ -247,12 +219,13 @@ class TestWavefunctionIntegration(BaseTest):
             qml.Rot(x, y, z, wires=0)
             return qml.expval.PauliZ(0)
 
+        print(circuit(a, b, c))
         self.assertAlmostEqual(circuit(a, b, c), np.cos(a)*np.sin(b), delta=tol)
 
-    def test_two_qubit_wavefunction_circuit(self, tol, qvm, compiler):
+    def test_two_qubit_wavefunction_circuit(self, tol):
         """Test that the wavefunction plugin provides correct result for simple 2-qubit circuit,
         even when the number of wires > number of qubits."""
-        dev = qml.device('forest.wavefunction', wires=3)
+        dev = qml.device('forest.numpy', wires=3)
 
         a = 0.543
         b = 0.123
@@ -272,10 +245,10 @@ class TestWavefunctionIntegration(BaseTest):
 
         self.assertAlmostEqual(circuit(theta, a, b, c), -np.sin(b/2)**2*np.sin(2*theta), delta=tol)
 
-    def test_nonzero_shots(self, qvm, compiler):
+    def test_nonzero_shots(self):
         """Test that the wavefunction plugin provides correct result for high shot number"""
         shots = 10**2
-        dev = qml.device('forest.wavefunction', wires=1, shots=shots)
+        dev = qml.device('forest.numpy', wires=1, shots=shots)
 
         a = 0.543
         b = 0.123
@@ -294,4 +267,5 @@ class TestWavefunctionIntegration(BaseTest):
             runs.append(circuit(a, b, c))
 
         expected_var = np.sqrt(1/shots)
+        print(np.mean(runs), np.cos(a)*np.sin(b))
         self.assertAlmostEqual(np.mean(runs), np.cos(a)*np.sin(b), delta=expected_var)

--- a/tests/test_pyqvm.py
+++ b/tests/test_pyqvm.py
@@ -22,7 +22,7 @@ class TestPyQVMBasic(BaseTest):
     """Unit tests for the pyQVM simulator."""
     # pylint: disable=protected-access
 
-    def test_identity_expectation(self, shots, compiler):
+    def test_identity_expectation(self, shots):
         """Test that identity expectation value (i.e. the trace) is 1"""
         theta = 0.432
         phi = 0.123
@@ -43,7 +43,7 @@ class TestPyQVMBasic(BaseTest):
         # below are the analytic expectation values for this circuit (trace should always be 1)
         self.assertAllAlmostEqual(res, np.array([1, 1]), delta=3/np.sqrt(shots))
 
-    def test_pauliz_expectation(self, shots, compiler):
+    def test_pauliz_expectation(self, shots):
         """Test that PauliZ expectation value is correct"""
         theta = 0.432
         phi = 0.123
@@ -64,7 +64,7 @@ class TestPyQVMBasic(BaseTest):
         # below are the analytic expectation values for this circuit
         self.assertAllAlmostEqual(res, np.array([np.cos(theta), np.cos(theta)*np.cos(phi)]), delta=3/np.sqrt(shots))
 
-    def test_paulix_expectation(self, shots, compiler):
+    def test_paulix_expectation(self, shots):
         """Test that PauliX expectation value is correct"""
         theta = 0.432
         phi = 0.123
@@ -84,7 +84,7 @@ class TestPyQVMBasic(BaseTest):
         # below are the analytic expectation values for this circuit
         self.assertAllAlmostEqual(res, np.array([np.sin(theta)*np.sin(phi), np.sin(phi)]), delta=3/np.sqrt(shots))
 
-    def test_pauliy_expectation(self, shots, compiler):
+    def test_pauliy_expectation(self, shots):
         """Test that PauliY expectation value is correct"""
         theta = 0.432
         phi = 0.123
@@ -104,7 +104,7 @@ class TestPyQVMBasic(BaseTest):
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
         self.assertAllAlmostEqual(res, np.array([0, -np.cos(theta)*np.sin(phi)]), delta=3/np.sqrt(shots))
 
-    def test_hadamard_expectation(self, shots, compiler):
+    def test_hadamard_expectation(self, shots):
         """Test that Hadamard expectation value is correct"""
         theta = 0.432
         phi = 0.123
@@ -125,7 +125,7 @@ class TestPyQVMBasic(BaseTest):
         expected = np.array([np.sin(theta)*np.sin(phi)+np.cos(theta), np.cos(theta)*np.cos(phi)+np.sin(phi)])/np.sqrt(2)
         self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(shots))
 
-    def test_hermitian_expectation(self, shots, compiler):
+    def test_hermitian_expectation(self, shots):
         """Test that arbitrary Hermitian expectation values are correct"""
         theta = 0.432
         phi = 0.123
@@ -155,7 +155,7 @@ class TestPyQVMBasic(BaseTest):
         self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(shots))
 
     @pytest.mark.parametrize("gate", plf.QVMDevice._operation_map) #pylint: disable=protected-access
-    def test_apply(self, gate, apply_unitary, shots, compiler):
+    def test_apply(self, gate, apply_unitary, shots):
         """Test the application of gates"""
         dev = plf.QVMDevice(device='3q-pyqvm', shots=shots)
 
@@ -210,7 +210,7 @@ class TestQVMIntegration(BaseTest):
     """Test the pyQVM simulator works correctly from the PennyLane frontend."""
     #pylint: disable=no-self-use
 
-    def test_qubit_unitary(self, shots, compiler):
+    def test_qubit_unitary(self, shots):
         """Test that an arbitrary unitary operation works"""
         dev1 = qml.device('forest.qvm', device='3q-pyqvm', shots=shots)
         dev2 = qml.device('forest.qvm', device='9q-square-pyqvm', shots=shots)
@@ -232,7 +232,7 @@ class TestQVMIntegration(BaseTest):
         self.assertAllAlmostEqual(circuit2(), np.vdot(out_state, obs @ out_state), delta=3/np.sqrt(shots))
 
     @pytest.mark.parametrize('device', ['2q-pyqvm'])
-    def test_one_qubit_wavefunction_circuit(self, device, compiler):
+    def test_one_qubit_wavefunction_circuit(self, device):
         """Test that the wavefunction plugin provides correct result for simple circuit"""
         shots = 100000
         dev = qml.device('forest.qvm', device=device, shots=shots)

--- a/tests/test_pyqvm.py
+++ b/tests/test_pyqvm.py
@@ -1,5 +1,5 @@
 """
-Unit tests for the QVM simulator device.
+Unit tests for the pyQVM simulator device.
 """
 import logging
 
@@ -18,16 +18,16 @@ import pennylane_forest as plf
 log = logging.getLogger(__name__)
 
 
-class TestQVMBasic(BaseTest):
-    """Unit tests for the QVM simulator."""
+class TestPyQVMBasic(BaseTest):
+    """Unit tests for the pyQVM simulator."""
     # pylint: disable=protected-access
 
-    def test_identity_expectation(self, shots, qvm, compiler):
+    def test_identity_expectation(self, shots, compiler):
         """Test that identity expectation value (i.e. the trace) is 1"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
+        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
         dev.apply('RX', wires=[0], par=[theta])
         dev.apply('RX', wires=[1], par=[phi])
         dev.apply('CNOT', wires=[0, 1], par=[])
@@ -43,12 +43,12 @@ class TestQVMBasic(BaseTest):
         # below are the analytic expectation values for this circuit (trace should always be 1)
         self.assertAllAlmostEqual(res, np.array([1, 1]), delta=3/np.sqrt(shots))
 
-    def test_pauliz_expectation(self, shots, qvm, compiler):
+    def test_pauliz_expectation(self, shots, compiler):
         """Test that PauliZ expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
+        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
         dev.apply('RX', wires=[0], par=[theta])
         dev.apply('RX', wires=[1], par=[phi])
         dev.apply('CNOT', wires=[0, 1], par=[])
@@ -64,12 +64,12 @@ class TestQVMBasic(BaseTest):
         # below are the analytic expectation values for this circuit
         self.assertAllAlmostEqual(res, np.array([np.cos(theta), np.cos(theta)*np.cos(phi)]), delta=3/np.sqrt(shots))
 
-    def test_paulix_expectation(self, shots, qvm, compiler):
+    def test_paulix_expectation(self, shots, compiler):
         """Test that PauliX expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
+        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
         dev.apply('RY', wires=[0], par=[theta])
         dev.apply('RY', wires=[1], par=[phi])
         dev.apply('CNOT', wires=[0, 1], par=[])
@@ -84,12 +84,12 @@ class TestQVMBasic(BaseTest):
         # below are the analytic expectation values for this circuit
         self.assertAllAlmostEqual(res, np.array([np.sin(theta)*np.sin(phi), np.sin(phi)]), delta=3/np.sqrt(shots))
 
-    def test_pauliy_expectation(self, shots, qvm, compiler):
+    def test_pauliy_expectation(self, shots, compiler):
         """Test that PauliY expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
+        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
         dev.apply('RX', wires=[0], par=[theta])
         dev.apply('RX', wires=[1], par=[phi])
         dev.apply('CNOT', wires=[0, 1], par=[])
@@ -104,12 +104,12 @@ class TestQVMBasic(BaseTest):
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
         self.assertAllAlmostEqual(res, np.array([0, -np.cos(theta)*np.sin(phi)]), delta=3/np.sqrt(shots))
 
-    def test_hadamard_expectation(self, shots, qvm, compiler):
+    def test_hadamard_expectation(self, shots, compiler):
         """Test that Hadamard expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
+        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
         dev.apply('RY', wires=[0], par=[theta])
         dev.apply('RY', wires=[1], par=[phi])
         dev.apply('CNOT', wires=[0, 1], par=[])
@@ -125,12 +125,12 @@ class TestQVMBasic(BaseTest):
         expected = np.array([np.sin(theta)*np.sin(phi)+np.cos(theta), np.cos(theta)*np.cos(phi)+np.sin(phi)])/np.sqrt(2)
         self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(shots))
 
-    def test_hermitian_expectation(self, shots, qvm, compiler):
+    def test_hermitian_expectation(self, shots, compiler):
         """Test that arbitrary Hermitian expectation values are correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
+        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
         dev.apply('RY', wires=[0], par=[theta])
         dev.apply('RY', wires=[1], par=[phi])
         dev.apply('CNOT', wires=[0, 1], par=[])
@@ -155,9 +155,9 @@ class TestQVMBasic(BaseTest):
         self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(shots))
 
     @pytest.mark.parametrize("gate", plf.QVMDevice._operation_map) #pylint: disable=protected-access
-    def test_apply(self, gate, apply_unitary, shots, qvm, compiler):
+    def test_apply(self, gate, apply_unitary, shots, compiler):
         """Test the application of gates"""
-        dev = plf.QVMDevice(device='3q-qvm', shots=shots)
+        dev = plf.QVMDevice(device='3q-pyqvm', shots=shots)
 
         try:
             # get the equivalent pennylane operation class
@@ -207,50 +207,13 @@ class TestQVMBasic(BaseTest):
 
 
 class TestQVMIntegration(BaseTest):
-    """Test the QVM simulator works correctly from the PennyLane frontend."""
+    """Test the pyQVM simulator works correctly from the PennyLane frontend."""
     #pylint: disable=no-self-use
 
-    def test_load_qvm_device(self):
-        """Test that the QVM device loads correctly"""
-        dev = qml.device('forest.qvm', device='2q-qvm')
-        self.assertEqual(dev.num_wires, 2)
-        self.assertEqual(dev.shots, 1024)
-        self.assertEqual(dev.short_name, 'forest.qvm')
-
-    def test_load_qvm_device_from_topology(self):
-        """Test that the QVM device, from an input topology, loads correctly"""
-        topology = nx.complete_graph(2)
-        dev = qml.device('forest.qvm', device=topology)
-        self.assertEqual(dev.num_wires, 2)
-        self.assertEqual(dev.shots, 1024)
-        self.assertEqual(dev.short_name, 'forest.qvm')
-
-    def test_load_virtual_qpu_device(self):
-        """Test that the QPU simulators load correctly"""
-        qml.device('forest.qvm', device='Aspen-1-2Q-B')
-
-    def test_incorrect_qc_name(self):
-        """Test that exception is raised if name is incorrect"""
-        with pytest.raises(ValueError, message="QVM device string does not indicate the number of qubits"):
-            qml.device('forest.qvm', device='Aspen-1-B')
-
-    def test_incorrect_qc_type(self):
-        """Test that exception is raised device is not a string or graph"""
-        with pytest.raises(ValueError, message="Required argument device must be a string"):
-            qml.device('forest.qvm', device=3)
-
-    def test_qvm_args(self):
-        """Test that the QVM plugin requires correct arguments"""
-        with pytest.raises(TypeError, message="missing 2 required positional arguments: 'device' and 'wires'"):
-            qml.device('forest.qvm')
-
-        with pytest.raises(ValueError, message="Number of shots must be a postive integer"):
-            qml.device('forest.qvm', '2q-qvm', shots=0)
-
-    def test_qubit_unitary(self, shots, qvm, compiler):
+    def test_qubit_unitary(self, shots, compiler):
         """Test that an arbitrary unitary operation works"""
-        dev1 = qml.device('forest.qvm', device='3q-qvm', shots=shots)
-        dev2 = qml.device('forest.qvm', device='9q-square-qvm', shots=shots)
+        dev1 = qml.device('forest.qvm', device='3q-pyqvm', shots=shots)
+        dev2 = qml.device('forest.qvm', device='9q-square-pyqvm', shots=shots)
 
         def circuit():
             """Reference QNode"""
@@ -268,8 +231,8 @@ class TestQVMIntegration(BaseTest):
         self.assertAllAlmostEqual(circuit1(), np.vdot(out_state, obs @ out_state), delta=3/np.sqrt(shots))
         self.assertAllAlmostEqual(circuit2(), np.vdot(out_state, obs @ out_state), delta=3/np.sqrt(shots))
 
-    @pytest.mark.parametrize('device', ['2q-qvm', 'Aspen-1-2Q-B'])
-    def test_one_qubit_wavefunction_circuit(self, device, qvm, compiler):
+    @pytest.mark.parametrize('device', ['2q-pyqvm'])
+    def test_one_qubit_wavefunction_circuit(self, device, compiler):
         """Test that the wavefunction plugin provides correct result for simple circuit"""
         shots = 100000
         dev = qml.device('forest.qvm', device=device, shots=shots)


### PR DESCRIPTION
This PR adds support for the pyQVM (as added to pyQuil in version 2.3) to PennyLane.

Specifically:

* `qvm.py` modified to mention how to use the `pyQVM`. No changes to the code here were needed, as the pyQVM API is the same as the standard QVM API.
* New `NumpyWavefunctionDevice` added (shortname: `forest.numpy`), allowing access to the `NumpyWavefunctionSimulator` in the pyQVM.
* Two new tests added: `test_numpy_wavefunction.py` and `test_pyqvm.py`.
* `NumpyWavefunctionDevice` code documentation added
* `README.rst`, `index.rst`, and `usage.rst` updated to detail using the new pyQVM in the `forest.qvm` device, as well as the new `forest.numpy` device.

**Note:** there are significant differences between the `NumpyWavefunctionSimulator` and the `WavefunctionSimulator`, including:
1. The `WavefunctionSimulator` adds qubits dynamically during program execution, `NumpyWavefunctionSimulator` must be initialized with the correct number of qubits.
2. `WavefunctionSimulator` stores the state with the least significant qubit on the left, `NumpyWavefunctionSimulator` stores the state with the *most* significant qubit on the left.
3. The APIs are currently incompatible. See https://github.com/rigetti/pyquil/pull/552#issuecomment-449115019.

As a result, for now, it makes more sense to have separate device for the Numpy wavefunction simulator, until at least https://github.com/rigetti/pyquil/issues/779 is implemented.