### PR TITLE
Added build and documentation badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,13 @@
 PennyLane Forest Plugin
 #######################
 
+.. image:: https://semaphoreci.com/api/v1/rigetti/pennylane-forest/branches/master/badge.svg
+    :alt: Build Status
+    :target: https://semaphoreci.com/rigetti/pennylane-forest
+
+.. image:: https://readthedocs.org/projects/pennylane-forest/badge/?version=latest
+    :alt: Documentation Status
+    :target: http://pennylane-forest.readthedocs.io/en/latest/?badge=latest
 
 Contains the PennyLane Forest plugin. This plugin allows three Rigetti devices to work with PennyLane - the wavefunction simulator, the Quantum Virtual Machine (QVM), and Quantum Processing Units (QPUs).
 


### PR DESCRIPTION
This PR adds two badges to the readme: one to represent the current SemaphoreCI build status, and another to show the current read the docs build status.