### PR TITLE
Updating compiler urls

### DIFF
--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -169,13 +169,13 @@ class ForestDevice(Device):
 
     Keyword args:
         forest_url (str): the Forest URL server. Can also be set by
-            the environment variable ``FOREST_SERVER_URL``, or in the ``~/.qcs_config``
+            the environment variable ``FOREST_URL``, or in the ``~/.qcs_config``
             configuration file. Default value is ``"https://forest-server.qcs.rigetti.com"``.
         qvm_url (str): the QVM server URL. Can also be set by the environment
             variable ``QVM_URL``, or in the ``~/.forest_config`` configuration file.
             Default value is ``"http://127.0.0.1:5000"``.
-        compiler_url (str): the compiler server URL. Can also be set by the environment
-            variable ``COMPILER_URL``, or in the ``~/.forest_config`` configuration file.
+        quilc_url (str): the compiler server URL. Can also be set by the environment
+            variable ``QUILC_URL``, or in the ``~/.forest_config`` configuration file.
             Default value is ``"http://127.0.0.1:6000"``.
     """
     pennylane_requires = '>=0.2'
@@ -186,9 +186,9 @@ class ForestDevice(Device):
 
     def __init__(self, wires, shots, **kwargs):
         super().__init__(wires, shots)
-        self.forest_url = kwargs.get('forest_url', pyquil_config.compiler_url)
+        self.forest_url = kwargs.get('forest_url', pyquil_config.forest_url)
         self.qvm_url = kwargs.get('qvm_url', pyquil_config.qvm_url)
-        self.compiler_url = kwargs.get('compiler_url', pyquil_config.compiler_url)
+        self.compiler_url = kwargs.get('compiler_url', pyquil_config.quilc_url)
 
         self.connection = ForestConnection(
             sync_endpoint=self.qvm_url,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,7 +139,7 @@ def compiler():
     try:
         config = PyquilConfig()
         device = get_qc('3q-qvm').device
-        compiler = QVMCompiler(endpoint=config.compiler_url, device=device)
+        compiler = QVMCompiler(endpoint=config.quilc_url, device=device)
         compiler.quil_to_native_quil(Program(Id(0)))
         return compiler
     except (RequestException, UnknownApiError, TypeError) as e:

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -227,7 +227,7 @@ class TestQVMIntegration(BaseTest):
 
     def test_load_virtual_qpu_device(self):
         """Test that the QPU simulators load correctly"""
-        qml.device('forest.qvm', device='Aspen-1-2Q-B')
+        qml.device('forest.qvm', device='Aspen-3-2Q-C')
 
     def test_incorrect_qc_name(self):
         """Test that exception is raised if name is incorrect"""
@@ -268,7 +268,7 @@ class TestQVMIntegration(BaseTest):
         self.assertAllAlmostEqual(circuit1(), np.vdot(out_state, obs @ out_state), delta=3/np.sqrt(shots))
         self.assertAllAlmostEqual(circuit2(), np.vdot(out_state, obs @ out_state), delta=3/np.sqrt(shots))
 
-    @pytest.mark.parametrize('device', ['2q-qvm', 'Aspen-1-2Q-B'])
+    @pytest.mark.parametrize('device', ['2q-qvm', 'Aspen-3-2Q-C'])
     def test_one_qubit_wavefunction_circuit(self, device, qvm, compiler):
         """Test that the wavefunction plugin provides correct result for simple circuit"""
         shots = 100000


### PR DESCRIPTION
Making small updates to compiler endpoints due to the recent change in pyquil 2.6:

`Bifurcated the QPUCompiler endpoint parameter into two -- quilc_endpoint and qpu_compiler_endpoint -- to reflect changes in Quantum Cloud Services (gh-856)`