### PR TITLE
Incremented version number

### DIFF
--- a/pennylane_forest/_version.py
+++ b/pennylane_forest/_version.py
@@ -2,4 +2,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.1.1'
+__version__ = '0.2.0'


### PR DESCRIPTION
Now that #10 is merged, this increments the version number to v0.2, in preparation for release onto PyPI.

This addresses #11.