### PR TITLE
[WIP] Bug fixes to allow PennyLane forest to work with pyQuil 2.8

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from pyquil.gates import I as Id
 from pyquil.api import QVMConnection, QVMCompiler, local_qvm
 from pyquil.api._config import PyquilConfig
 from pyquil.api._errors import UnknownApiError
+from pyquil.api._qvm import QVMNotRunning
 
 
 # defaults
@@ -130,7 +131,7 @@ def qvm():
         qvm = QVMConnection(random_seed=52)
         qvm.run(Program(Id(0)), [])
         return qvm
-    except (RequestException, UnknownApiError, TypeError) as e:
+    except (RequestException, UnknownApiError, QVMNotRunning, TypeError) as e:
         return pytest.skip("This test requires QVM connection: {}".format(e))
 
 
@@ -142,7 +143,7 @@ def compiler():
         compiler = QVMCompiler(endpoint=config.quilc_url, device=device)
         compiler.quil_to_native_quil(Program(Id(0)))
         return compiler
-    except (RequestException, UnknownApiError, TypeError) as e:
+    except (RequestException, UnknownApiError, QVMNotRunning, TypeError) as e:
         return pytest.skip("This test requires compiler connection: {}".format(e))
 
 


### PR DESCRIPTION
This work-in-progress PR fixes two bugs in PLF:

1. `conftest.py`: adds `QVMNotRunning` to the list of exceptions in the `qvm()` and `compiler()` fixtures, to indicate that QVM and Quilc aren't available.

2. `qvm.py`: the behaviour of `get_qc` has changed; although the documentation specifies that `get_qc` should accept a device with string of form `Xq-pyqvm` to load the pyQVM, `get_qc` now explicitly attempts to connect to an external compiler.

   To get around this, I have done the following in `qvm.py`:

   ```python
   if "pyqvm" in device:
       self.qc = PyQVM(n_qubits=num_wires)
   else:
       self.qc = get_qc(device, as_qvm=True, noisy=noisy, connection=self.connection)
    ```

   And, in the `pre_expval()` method, added the follow if statement:

   ```python
   if "pyqvm" in self.device_name:
       self.qc.load(self.prog)
       self.qc.run()
       bitstring_array = self.qc._bitstrings
   else:
       executable = self.qc.compile(self.prog)
       bitstring_array = self.qc.run(executable=executable)
   ```

   However, this currently doesn't work, as `PyQVM` doesn't currently set the `self._bitstrings` attribute for some reason?