### PR TITLE
Adds variance support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Features
 * Provides four devices to be used with PennyLane: ``forest.numpy_wavefunction``, ``forest.wavefunction``, ``forest.qvm``, and ``forest.qpu``. These provide access to the pyQVM Numpy wavefunction simulator, Forest wavefunction simulator, quantum virtual machine (QVM), and quantum processing unit (QPU) respectively.
 
 
-* All provided devices support all core qubit PennyLane operations and expectation values.
+* All provided devices support all core qubit PennyLane operations and observables.
 
 
 * Provides custom PennyLane operations to cover additional pyQuil operations: ``T``, ``S``, ``ISWAP``, ``CCNOT``, ``PSWAP``, and many more. Every custom operation supports analytic differentiation.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,7 +19,7 @@ Features
 * Provides four devices to be used with PennyLane: ``forest.numpy_wavefunction``, ``forest.wavefunction``, ``forest.qvm``, and ``forest.qpu``. These provide access to the pyQVM Numpy wavefunction simulator, Forest wavefunction simulator, quantum virtual machine (QVM), and quantum processing unit (QPU) respectively.
 
 
-* All provided devices support all core qubit PennyLane operations and expectation values.
+* All provided devices support all core qubit PennyLane operations and observables.
 
 
 * Provides custom PennyLane operations to cover additional pyQuil operations: ``T``, ``S``, ``ISWAP``, ``CCNOT``, ``PSWAP``, and many more. Every custom operation supports analytic differentiation.

--- a/pennylane_forest/__init__.py
+++ b/pennylane_forest/__init__.py
@@ -2,7 +2,7 @@
 Plugin overview
 ===============
 """
-from .ops import (S, T, CCNOT, CPHASE, CSWAP, ISWAP, PSWAP)
+from .ops import S, T, CCNOT, CPHASE, CSWAP, ISWAP, PSWAP
 from .qpu import QPUDevice
 from .qvm import QVMDevice
 from .wavefunction import WavefunctionDevice

--- a/pennylane_forest/_version.py
+++ b/pennylane_forest/_version.py
@@ -2,4 +2,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.3.0'
+__version__ = "0.3.0"

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -39,9 +39,10 @@ from pyquil.api._base_connection import ForestConnection
 from pyquil.api._config import PyquilConfig
 
 from pyquil.quil import DefGate
-from pyquil.gates import (X, Y, Z, H, PHASE, RX, RY, RZ, CZ, SWAP, CNOT)
+from pyquil.gates import X, Y, Z, H, PHASE, RX, RY, RZ, CZ, SWAP, CNOT
+
 # following gates are not supported by PennyLane
-from pyquil.gates import (S, T, CPHASE00, CPHASE01, CPHASE10, CPHASE, CCNOT, CSWAP, ISWAP, PSWAP)
+from pyquil.gates import S, T, CPHASE00, CPHASE01, CPHASE10, CPHASE, CCNOT, CSWAP, ISWAP, PSWAP
 
 from pennylane import Device
 
@@ -83,8 +84,8 @@ def qubit_unitary(par, *wires):
     if not np.allclose(par @ par.conj().T, np.identity(par.shape[0])):
         raise ValueError("Qubit unitary matrix must be unitary.")
 
-    if par.shape != tuple([2**len(wires)]*2):
-        raise ValueError('Qubit unitary matrix must be 2^Nx2^N, where N is the number of wires.')
+    if par.shape != tuple([2 ** len(wires)] * 2):
+        raise ValueError("Qubit unitary matrix must be 2^Nx2^N, where N is the number of wires.")
 
     # Get the Quil definition for the new gate
     gate_definition = DefGate("U_{}".format(str(uuid.uuid4())[:8]), par)
@@ -133,28 +134,28 @@ def controlled_phase(phi, q, *wires):
 # mapping operations supported by PennyLane to the
 # corresponding pyQuil operation
 pyquil_operation_map = {
-    'BasisState': basis_state,
-    'QubitUnitary': qubit_unitary,
+    "BasisState": basis_state,
+    "QubitUnitary": qubit_unitary,
     "PauliX": X,
     "PauliY": Y,
     "PauliZ": Z,
     "Hadamard": H,
-    'CNOT': CNOT,
-    'SWAP': SWAP,
-    'CZ': CZ,
-    'PhaseShift': PHASE,
-    'RX': RX,
-    'RY': RY,
-    'RZ': RZ,
-    'Rot': rotation,
+    "CNOT": CNOT,
+    "SWAP": SWAP,
+    "CZ": CZ,
+    "PhaseShift": PHASE,
+    "RX": RX,
+    "RY": RY,
+    "RZ": RZ,
+    "Rot": rotation,
     # the following gates are provided by the PL-Forest plugin
-    'S': S,
-    'T': T,
-    'CCNOT': CCNOT,
-    'CPHASE': controlled_phase,
-    'CSWAP': CSWAP,
-    'ISWAP': ISWAP,
-    'PSWAP': PSWAP,
+    "S": S,
+    "T": T,
+    "CCNOT": CCNOT,
+    "CPHASE": controlled_phase,
+    "CSWAP": CSWAP,
+    "ISWAP": ISWAP,
+    "PSWAP": PSWAP,
 }
 
 
@@ -178,24 +179,23 @@ class ForestDevice(Device):
             variable ``QUILC_URL``, or in the ``~/.forest_config`` configuration file.
             Default value is ``"http://127.0.0.1:6000"``.
     """
-    pennylane_requires = '>=0.4'
+    pennylane_requires = ">=0.4"
     version = __version__
-    author = 'Josh Izaac'
+    author = "Josh Izaac"
 
     _operation_map = pyquil_operation_map
 
     def __init__(self, wires, shots, **kwargs):
         super().__init__(wires, shots)
-        self.forest_url = kwargs.get('forest_url', pyquil_config.forest_url)
-        self.qvm_url = kwargs.get('qvm_url', pyquil_config.qvm_url)
-        self.compiler_url = kwargs.get('compiler_url', pyquil_config.quilc_url)
+        self.forest_url = kwargs.get("forest_url", pyquil_config.forest_url)
+        self.qvm_url = kwargs.get("qvm_url", pyquil_config.qvm_url)
+        self.compiler_url = kwargs.get("compiler_url", pyquil_config.quilc_url)
 
         self.connection = ForestConnection(
             sync_endpoint=self.qvm_url,
             compiler_endpoint=self.compiler_url,
-            forest_cloud_endpoint=self.forest_url
+            forest_cloud_endpoint=self.forest_url,
         )
-
 
         # The following environment variables are deprecated I think
 
@@ -234,7 +234,7 @@ class ForestDevice(Device):
             self.active_wires = set(range(self.num_wires))
 
     @abc.abstractmethod
-    def pre_measure(self): #pragma no cover
+    def pre_measure(self):  # pragma no cover
         """Run the QVM or QPU"""
         raise NotImplementedError
 

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -178,7 +178,7 @@ class ForestDevice(Device):
             variable ``QUILC_URL``, or in the ``~/.forest_config`` configuration file.
             Default value is ``"http://127.0.0.1:6000"``.
     """
-    pennylane_requires = '>=0.2'
+    pennylane_requires = '>=0.4'
     version = __version__
     author = 'Josh Izaac'
 

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -39,10 +39,10 @@ class NumpyWavefunctionDevice(ForestDevice):
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables.
     """
-    name = 'pyQVM NumpyWavefunction Simulator Device'
-    short_name = 'forest.numpy_wavefunction'
+    name = "pyQVM NumpyWavefunction Simulator Device"
+    short_name = "forest.numpy_wavefunction"
 
-    observables = {'PauliX', 'PauliY', 'PauliZ', 'Hadamard', 'Hermitian', 'Identity'}
+    observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Hermitian", "Identity"}
 
     def __init__(self, wires, *, shots=0, **kwargs):
         super().__init__(wires, shots, **kwargs)
@@ -58,11 +58,11 @@ class NumpyWavefunctionDevice(ForestDevice):
         # returns amplitudes in the opposite of the Rigetti Lisp QVM (which considers qubit
         # 0 as the rightmost bit). This may change in the future, so in the future this
         # might need to get udpated to be similar to the pre_measure function of
-        #pennylane_forest/wavefunction.py
+        # pennylane_forest/wavefunction.py
         self.state = self.qc.execute(self.prog).wf_simulator.wf.flatten()
 
     def expval(self, observable, wires, par):
-        if observable == 'Hermitian':
+        if observable == "Hermitian":
             A = par[0]
         else:
             A = observable_map[observable]
@@ -76,17 +76,17 @@ class NumpyWavefunctionDevice(ForestDevice):
             a, P = spectral_decomposition_qubit(A)
             p0 = self.ev(P[0], wires)  # probability of measuring a[0]
             n0 = np.random.binomial(self.shots, p0)
-            ev = (n0*a[0] +(self.shots-n0)*a[1]) / self.shots
+            ev = (n0 * a[0] + (self.shots - n0) * a[1]) / self.shots
 
         return ev
 
     def var(self, observable, wires, par):
-        if observable == 'Hermitian':
+        if observable == "Hermitian":
             A = par[0]
         else:
             A = observable_map[observable]
 
-        var = self.ev(A@A, wires) - self.ev(A, wires)**2
+        var = self.ev(A @ A, wires) - self.ev(A, wires) ** 2
         return var
 
     def ev(self, A, wires):
@@ -124,26 +124,26 @@ class NumpyWavefunctionDevice(ForestDevice):
         if np.any(wires < 0) or np.any(wires >= N) or len(set(wires)) != len(wires):
             raise ValueError("Invalid target subsystems provided in 'wires' argument.")
 
-        if U.shape != (2**len(wires), 2**len(wires)):
+        if U.shape != (2 ** len(wires), 2 ** len(wires)):
             raise ValueError("Matrix parameter must be of size (2**len(wires), 2**len(wires))")
 
         # generate N qubit basis states via the cartesian product
         tuples = np.array(list(itertools.product([0, 1], repeat=N)))
 
         # wires not acted on by the operator
-        inactive_wires = list(set(range(N))-set(wires))
+        inactive_wires = list(set(range(N)) - set(wires))
 
         # expand U to act on the entire system
-        U = np.kron(U, np.identity(2**len(inactive_wires)))
+        U = np.kron(U, np.identity(2 ** len(inactive_wires)))
 
         # move active wires to beginning of the list of wires
-        rearranged_wires = np.array(list(wires)+inactive_wires)
+        rearranged_wires = np.array(list(wires) + inactive_wires)
 
         # convert to computational basis
         # i.e., converting the list of basis state bit strings into
         # a list of decimal numbers that correspond to the computational
         # basis state. For example, [0, 1, 0, 1, 1] = 2^3+2^1+2^0 = 11.
-        perm = np.ravel_multi_index(tuples[:, rearranged_wires].T, [2]*N)
+        perm = np.ravel_multi_index(tuples[:, rearranged_wires].T, [2] * N)
 
         # permute U to take into account rearranged wires
         return U[:, perm][perm]

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -80,6 +80,15 @@ class NumpyWavefunctionDevice(ForestDevice):
 
         return ev
 
+    def var(self, observable, wires, par):
+        if observable == 'Hermitian':
+            A = par[0]
+        else:
+            A = observable_map[observable]
+
+        var = self.ev(A@A, wires) - self.ev(A, wires)**2
+        return var
+
     def ev(self, A, wires):
         r"""Evaluates a one-qubit expectation in the current state.
 

--- a/pennylane_forest/ops.py
+++ b/pennylane_forest/ops.py
@@ -125,8 +125,8 @@ class CPHASE(Operation):
     """
     num_params = 2
     num_wires = 2
-    par_domain = 'R'
-    grad_method = 'A'
+    par_domain = "R"
+    grad_method = "A"
 
 
 class CSWAP(Operation):
@@ -207,5 +207,5 @@ class PSWAP(Operation):
     """
     num_params = 1
     num_wires = 2
-    par_domain = 'R'
-    grad_method = 'A'
+    par_domain = "R"
+    grad_method = "A"

--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -52,22 +52,24 @@ class QPUDevice(QVMDevice):
             variable ``COMPILER_URL``, or in the ``~/.forest_config`` configuration file.
             Default value is ``"http://127.0.0.1:6000"``.
     """
-    name = 'Forest QPU Device'
-    short_name = 'forest.qpu'
+    name = "Forest QPU Device"
+    short_name = "forest.qpu"
 
     def __init__(self, device, *, shots=1024, active_reset=False, load_qc=True, **kwargs):
         self._eigs = {}
 
-        if 'wires' in kwargs:
+        if "wires" in kwargs:
             raise ValueError("QPU device does not support a wires parameter.")
 
         if shots <= 0:
             raise ValueError("Number of shots must be a positive integer.")
 
-        aspen_match = re.match(r'Aspen-\d+-([\d]+)Q', device)
+        aspen_match = re.match(r"Aspen-\d+-([\d]+)Q", device)
         num_wires = int(aspen_match.groups()[0])
 
-        super(QVMDevice, self).__init__(num_wires, shots, **kwargs) #pylint: disable=bad-super-call
+        super(QVMDevice, self).__init__(
+            num_wires, shots, **kwargs
+        )  # pylint: disable=bad-super-call
 
         if load_qc:
             self.qc = get_qc(device, as_qvm=False, connection=self.connection)

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -64,9 +64,9 @@ class QVMDevice(ForestDevice):
             variable ``COMPILER_URL``, or in the ``~/.forest_config`` configuration file.
             Default value is ``"http://127.0.0.1:6000"``.
     """
-    name = 'Forest QVM Device'
-    short_name = 'forest.qvm'
-    observables = {'PauliX', 'PauliY', 'PauliZ', 'Identity', 'Hadamard', 'Hermitian'}
+    name = "Forest QVM Device"
+    short_name = "forest.qvm"
+    observables = {"PauliX", "PauliY", "PauliZ", "Identity", "Hadamard", "Hermitian"}
 
     def __init__(self, device, *, shots=1024, noisy=False, **kwargs):
         self._eigs = {}
@@ -75,7 +75,7 @@ class QVMDevice(ForestDevice):
             raise ValueError("Number of shots must be a positive integer.")
 
         # ignore any 'wires' keyword argument passed to the device
-        kwargs.pop('wires', None)
+        kwargs.pop("wires", None)
 
         # get the number of wires
         if isinstance(device, nx.Graph):
@@ -84,7 +84,7 @@ class QVMDevice(ForestDevice):
         elif isinstance(device, str):
             # the device string must match a valid QVM device, i.e.
             # N-qvm, or 9q-square-qvm, or Aspen-1-16Q-A
-            wire_match = re.search(r'(\d+)(q|Q)', device)
+            wire_match = re.search(r"(\d+)(q|Q)", device)
 
             if wire_match is None:
                 # with the current Rigetti naming scheme, this error should never
@@ -93,14 +93,18 @@ class QVMDevice(ForestDevice):
 
             num_wires = int(wire_match.groups()[0])
         else:
-            raise ValueError("Required argument device must be a string corresponding to "
-                             "a valid QVM quantum computer, or a NetworkX graph object.")
+            raise ValueError(
+                "Required argument device must be a string corresponding to "
+                "a valid QVM quantum computer, or a NetworkX graph object."
+            )
 
         super().__init__(num_wires, shots, **kwargs)
 
         # get the qc
         if isinstance(device, nx.Graph):
-            self.qc = _get_qvm_with_topology('device', topology=device, noisy=noisy, connection=self.connection)
+            self.qc = _get_qvm_with_topology(
+                "device", topology=device, noisy=noisy, connection=self.connection
+            )
         elif isinstance(device, str):
             self.qc = get_qc(device, as_qvm=True, noisy=noisy, connection=self.connection)
 
@@ -112,21 +116,21 @@ class QVMDevice(ForestDevice):
         for e in self.obs_queue:
             wires = e.wires
 
-            if e.name == 'PauliX':
+            if e.name == "PauliX":
                 # X = H.Z.H
-                self.apply('Hadamard', wires, [])
+                self.apply("Hadamard", wires, [])
 
-            elif e.name == 'PauliY':
+            elif e.name == "PauliY":
                 # Y = (HS^)^.Z.(HS^) and S^=SZ
-                self.apply('PauliZ', wires, [])
-                self.apply('S', wires, [])
-                self.apply('Hadamard', wires, [])
+                self.apply("PauliZ", wires, [])
+                self.apply("S", wires, [])
+                self.apply("Hadamard", wires, [])
 
-            elif e.name == 'Hadamard':
+            elif e.name == "Hadamard":
                 # H = Ry(-pi/4)^.Z.Ry(-pi/4)
-                self.apply('RY', wires, [-np.pi/4])
+                self.apply("RY", wires, [-np.pi / 4])
 
-            elif e.name == 'Hermitian':
+            elif e.name == "Hermitian":
                 # For arbitrary Hermitian matrix H, let U be the unitary matrix
                 # that diagonalises it, and w_i be the eigenvalues.
                 H = e.parameters[0]
@@ -134,18 +138,18 @@ class QVMDevice(ForestDevice):
 
                 if Hkey in self._eigs:
                     # retrieve eigenvectors
-                    U = self._eigs[Hkey]['eigvec']
+                    U = self._eigs[Hkey]["eigvec"]
                 else:
                     # store the eigenvalues corresponding to H
                     # in a dictionary, so that they do not need to
                     # be calculated later
                     w, U = np.linalg.eigh(H)
-                    self._eigs[Hkey] = {'eigval': w, 'eigvec': U}
+                    self._eigs[Hkey] = {"eigval": w, "eigvec": U}
 
                 # Perform a change of basis before measuring by applying U^ to the circuit
-                self.apply('QubitUnitary', wires, [U.conj().T])
+                self.apply("QubitUnitary", wires, [U.conj().T])
 
-        prag = Program(Pragma('INITIAL_REWIRING', ['"PARTIAL"']))
+        prag = Program(Pragma("INITIAL_REWIRING", ['"PARTIAL"']))
 
         if self.active_reset:
             prag += RESET()
@@ -153,7 +157,7 @@ class QVMDevice(ForestDevice):
         self.prog = prag + self.prog
 
         qubits = list(self.prog.get_qubits())
-        ro = self.prog.declare('ro', 'BIT', len(qubits))
+        ro = self.prog.declare("ro", "BIT", len(qubits))
         for i, q in enumerate(qubits):
             self.prog.inst(MEASURE(q, ro[i]))
 
@@ -172,22 +176,22 @@ class QVMDevice(ForestDevice):
     def expval(self, observable, wires, par):
         if len(wires) == 1:
             # 1 qubit observable
-            evZ = np.mean(1-2*self.state[wires[0]])
+            evZ = np.mean(1 - 2 * self.state[wires[0]])
 
             # for single qubit state probabilities |psi|^2 = (p0, p1),
             # we know that p0+p1=1 and that <Z>=p0-p1
-            p0 = (1+evZ)/2
-            p1 = (1-evZ)/2
+            p0 = (1 + evZ) / 2
+            p1 = (1 - evZ) / 2
 
-            if observable == 'Identity':
+            if observable == "Identity":
                 # <I> = \sum_i p_i
                 return p0 + p1
 
-            if observable == 'Hermitian':
+            if observable == "Hermitian":
                 # <H> = \sum_i w_i p_i
                 Hkey = tuple(par[0].flatten().tolist())
-                w = self._eigs[Hkey]['eigval']
-                return w[0]*p0 + w[1]*p1
+                w = self._eigs[Hkey]["eigval"]
+                return w[0] * p0 + w[1] * p1
 
             return evZ
 
@@ -201,9 +205,9 @@ class QVMDevice(ForestDevice):
 
         probs = self.probabilities(wires)
 
-        if observable == 'Hermitian':
+        if observable == "Hermitian":
             Hkey = tuple(par[0].flatten().tolist())
-            w = self._eigs[Hkey]['eigval']
+            w = self._eigs[Hkey]["eigval"]
             # <A> = \sum_i w_i p_i
             return w @ probs
 
@@ -222,15 +226,15 @@ class QVMDevice(ForestDevice):
 
         # create an array of size [2^len(wires), 2] to store
         # the resulting probability of each computational basis state
-        probs = np.zeros([2**len(wires), 2])
-        probs[:, 0] = np.arange(2**len(wires))
+        probs = np.zeros([2 ** len(wires), 2])
+        probs[:, 0] = np.arange(2 ** len(wires))
 
         # extract the measured samples
         res = np.array([self.state[w] for w in wires]).T
         for i in res:
             # for each sample, calculate which
             # computational basis state it corresponds to
-            cb = np.sum(2**np.arange(len(wires)-1, -1, -1)*i)
+            cb = np.sum(2 ** np.arange(len(wires) - 1, -1, -1) * i)
             # add a tally for this computational basis state
             # to our array of basis probabilities
             probs[cb, 1] += 1
@@ -245,24 +249,24 @@ class QVMDevice(ForestDevice):
     def var(self, observable, wires, par):
         if len(wires) == 1:
             # 1 qubit observable
-            if observable == 'Identity':
+            if observable == "Identity":
                 return 0
 
-            varZ = np.var(1-2*self.state[wires[0]])
+            varZ = np.var(1 - 2 * self.state[wires[0]])
 
-            if observable in {'PauliX', 'PauliY', 'PauliZ', 'Hadamard'}:
+            if observable in {"PauliX", "PauliY", "PauliZ", "Hadamard"}:
                 return varZ
 
             # for single qubit state probabilities |psi|^2 = (p0, p1),
             # we know that p0+p1=1 and that <Z>=p0-p1
-            evZ = np.mean(1-2*self.state[wires[0]])
-            probs = np.array([(1+evZ)/2, (1-evZ)/2])
+            evZ = np.mean(1 - 2 * self.state[wires[0]])
+            probs = np.array([(1 + evZ) / 2, (1 - evZ) / 2])
 
-            if observable == 'Hermitian':
+            if observable == "Hermitian":
                 # <H> = \sum_i w_i p_i
                 Hkey = tuple(par[0].flatten().tolist())
-                w = self._eigs[Hkey]['eigval']
-                return (w**2) @ probs - (w @ probs)**2
+                w = self._eigs[Hkey]["eigval"]
+                return (w ** 2) @ probs - (w @ probs) ** 2
 
         # Multi-qubit observable
         # ----------------------
@@ -274,8 +278,8 @@ class QVMDevice(ForestDevice):
 
         probs = self.probabilities(wires)
 
-        if observable == 'Hermitian':
+        if observable == "Hermitian":
             Hkey = tuple(par[0].flatten().tolist())
-            w = self._eigs[Hkey]['eigval']
+            w = self._eigs[Hkey]["eigval"]
             # <A> = \sum_i w_i p_i
-            return (w**2) @ probs - (w @ probs)**2
+            return (w ** 2) @ probs - (w @ probs) ** 2

--- a/pennylane_forest/wavefunction.py
+++ b/pennylane_forest/wavefunction.py
@@ -142,6 +142,15 @@ class WavefunctionDevice(ForestDevice):
 
         return ev
 
+    def var(self, observable, wires, par):
+        if observable == 'Hermitian':
+            A = par[0]
+        else:
+            A = observable_map[observable]
+
+        var = self.ev(A@A, wires) - self.ev(A, wires)**2
+        return var
+
     def ev(self, A, wires):
         r"""Evaluates a one-qubit expectation in the current state.
 

--- a/pennylane_forest/wavefunction.py
+++ b/pennylane_forest/wavefunction.py
@@ -37,13 +37,13 @@ from ._version import __version__
 
 
 I = np.identity(2)
-X = np.array([[0, 1], [1, 0]]) #: Pauli-X matrix
-Y = np.array([[0, -1j], [1j, 0]]) #: Pauli-Y matrix
-Z = np.array([[1, 0], [0, -1]]) #: Pauli-Z matrix
-H = np.array([[1, 1], [1, -1]])/np.sqrt(2) # Hadamard matrix
+X = np.array([[0, 1], [1, 0]])  #: Pauli-X matrix
+Y = np.array([[0, -1j], [1j, 0]])  #: Pauli-Y matrix
+Z = np.array([[1, 0], [0, -1]])  #: Pauli-Z matrix
+H = np.array([[1, 1], [1, -1]]) / np.sqrt(2)  # Hadamard matrix
 
 
-observable_map = {'PauliX': X, 'PauliY': Y, 'PauliZ': Z, 'Identity': I, 'Hadamard': H}
+observable_map = {"PauliX": X, "PauliY": Y, "PauliZ": Z, "Identity": I, "Hadamard": H}
 
 
 def spectral_decomposition_qubit(A):
@@ -83,10 +83,10 @@ class WavefunctionDevice(ForestDevice):
             variable ``COMPILER_URL``, or in the ``~/.forest_config`` configuration file.
             Default value is ``"http://127.0.0.1:6000"``.
     """
-    name = 'Forest Wavefunction Simulator Device'
-    short_name = 'forest.wavefunction'
+    name = "Forest Wavefunction Simulator Device"
+    short_name = "forest.wavefunction"
 
-    observables = {'PauliX', 'PauliY', 'PauliZ', 'Hadamard', 'Hermitian', 'Identity'}
+    observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Hermitian", "Identity"}
 
     def __init__(self, wires, *, shots=0, **kwargs):
         super().__init__(wires, shots, **kwargs)
@@ -98,7 +98,7 @@ class WavefunctionDevice(ForestDevice):
 
         # pyQuil uses the convention that the first qubit is the least significant
         # qubit. Here, we reverse this to make it the last qubit, matching PennyLane convention.
-        self.state = self.state.reshape([2]*len(self.active_wires)).T.flatten()
+        self.state = self.state.reshape([2] * len(self.active_wires)).T.flatten()
         self.expand_state()
 
     def expand_state(self):
@@ -113,18 +113,20 @@ class WavefunctionDevice(ForestDevice):
         inactive_wires = set(range(self.num_wires)) - self.active_wires
 
         # place the inactive subsystems in the vacuum state
-        other_subsystems = np.zeros([2**len(inactive_wires)])
+        other_subsystems = np.zeros([2 ** len(inactive_wires)])
         other_subsystems[0] = 1
 
         # expand the state of the device into a length-num_wire state vector
-        expanded_state = np.kron(self.state, other_subsystems).reshape([2]*self.num_wires)
-        expanded_state = np.moveaxis(expanded_state, range(len(self.active_wires)), self.active_wires)
+        expanded_state = np.kron(self.state, other_subsystems).reshape([2] * self.num_wires)
+        expanded_state = np.moveaxis(
+            expanded_state, range(len(self.active_wires)), self.active_wires
+        )
         expanded_state = expanded_state.flatten()
 
         self.state = expanded_state
 
     def expval(self, observable, wires, par):
-        if observable == 'Hermitian':
+        if observable == "Hermitian":
             A = par[0]
         else:
             A = observable_map[observable]
@@ -138,17 +140,17 @@ class WavefunctionDevice(ForestDevice):
             a, P = spectral_decomposition_qubit(A)
             p0 = self.ev(P[0], wires)  # probability of measuring a[0]
             n0 = np.random.binomial(self.shots, p0)
-            ev = (n0*a[0] +(self.shots-n0)*a[1]) / self.shots
+            ev = (n0 * a[0] + (self.shots - n0) * a[1]) / self.shots
 
         return ev
 
     def var(self, observable, wires, par):
-        if observable == 'Hermitian':
+        if observable == "Hermitian":
             A = par[0]
         else:
             A = observable_map[observable]
 
-        var = self.ev(A@A, wires) - self.ev(A, wires)**2
+        var = self.ev(A @ A, wires) - self.ev(A, wires) ** 2
         return var
 
     def ev(self, A, wires):
@@ -186,26 +188,26 @@ class WavefunctionDevice(ForestDevice):
         if np.any(wires < 0) or np.any(wires >= N) or len(set(wires)) != len(wires):
             raise ValueError("Invalid target subsystems provided in 'wires' argument.")
 
-        if U.shape != (2**len(wires), 2**len(wires)):
+        if U.shape != (2 ** len(wires), 2 ** len(wires)):
             raise ValueError("Matrix parameter must be of size (2**len(wires), 2**len(wires))")
 
         # generate N qubit basis states via the cartesian product
         tuples = np.array(list(itertools.product([0, 1], repeat=N)))
 
         # wires not acted on by the operator
-        inactive_wires = list(set(range(N))-set(wires))
+        inactive_wires = list(set(range(N)) - set(wires))
 
         # expand U to act on the entire system
-        U = np.kron(U, np.identity(2**len(inactive_wires)))
+        U = np.kron(U, np.identity(2 ** len(inactive_wires)))
 
         # move active wires to beginning of the list of wires
-        rearranged_wires = np.array(list(wires)+inactive_wires)
+        rearranged_wires = np.array(list(wires) + inactive_wires)
 
         # convert to computational basis
         # i.e., converting the list of basis state bit strings into
         # a list of decimal numbers that correspond to the computational
         # basis state. For example, [0, 1, 0, 1, 1] = 2^3+2^1+2^0 = 11.
-        perm = np.ravel_multi_index(tuples[:, rearranged_wires].T, [2]*N)
+        perm = np.ravel_multi_index(tuples[:, rearranged_wires].T, [2] * N)
 
         # permute U to take into account rearranged wires
         return U[:, perm][perm]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyquil>=2.7
-pennylane>=0.2
+pennylane>=0.4
 networkx

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("pennylane_forest/_version.py") as f:
 
 requirements = [
     "pyquil>=2.7",
-    "pennylane>=0.2"
+    "pennylane>=0.4"
 ]
 
 info = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,11 +28,15 @@ Z = np.array([[1, 0], [0, -1]])
 
 
 SWAP = np.array([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
-CNOT = np.array([[1, 0, 0, 0], [0, 1, 0 ,0], [0, 0, 0, 1], [0, 0, 1, 0]])
+CNOT = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
 
 
-U = np.array([[0.83645892-0.40533293j, -0.20215326+0.30850569j],
-              [-0.23889780-0.28101519j, -0.88031770-0.29832709j]])
+U = np.array(
+    [
+        [0.83645892 - 0.40533293j, -0.20215326 + 0.30850569j],
+        [-0.23889780 - 0.28101519j, -0.88031770 - 0.29832709j],
+    ]
+)
 
 
 # U2 = np.array([[-0.07843244-3.57825948e-01j, 0.71447295-5.38069384e-02j, 0.20949966+6.59100734e-05j, -0.50297381+2.35731613e-01j],
@@ -41,24 +45,20 @@ U = np.array([[0.83645892-0.40533293j, -0.20215326+0.30850569j],
 #                [-0.09686189-3.15085273e-01j, -0.53241387-1.99491763e-01j, 0.56928622+3.97704398e-01j, -0.28671074-6.01574497e-02j]])
 
 
-U2 = np.array([[0, 1, 1, 1],
-               [1, 0, 1, -1],
-               [1, -1, 0, 1],
-               [1, 1, -1, 0]])/np.sqrt(3)
+U2 = np.array([[0, 1, 1, 1], [1, 0, 1, -1], [1, -1, 0, 1], [1, 1, -1, 0]]) / np.sqrt(3)
 
 
 U_toffoli = np.diag([1 for i in range(8)])
 U_toffoli[6:8, 6:8] = np.array([[0, 1], [1, 0]])
 
 
-H = np.array([[1.02789352, 1.61296440-0.3498192j],
-              [1.61296440+0.3498192j, 1.23920938+0j]])
+H = np.array([[1.02789352, 1.61296440 - 0.3498192j], [1.61296440 + 0.3498192j, 1.23920938 + 0j]])
 
 
 def controlled_phase(phi, q):
     """Returns the matrix representation of the controlled phase gate"""
     mat = np.identity(4, dtype=np.complex128)
-    mat[q, q] = np.exp(1j*phi)
+    mat[q, q] = np.exp(1j * phi)
     return mat
 
 
@@ -67,33 +67,35 @@ test_operation_map = {
     "PauliX": X,
     "PauliY": Y,
     "PauliZ": Z,
-    "Hadamard": np.array([[1, 1], [1, -1]])/np.sqrt(2),
-    'CNOT': block_diag(I, X),
-    'SWAP': SWAP,
-    'CZ': block_diag(I, Z),
-    'PhaseShift': lambda phi: np.array([[1, 0], [0, np.exp(1j*phi)]]),
-    'RX': lambda phi: expm(-1j * phi/2 * X),
-    'RY': lambda phi: expm(-1j * phi/2 * Y),
-    'RZ': lambda phi: expm(-1j * phi/2 * Z),
-    'Rot': lambda a, b, c: expm(-1j * c/2 * Z) @ expm(-1j * b/2 * Y) @ expm(-1j * a/2 * Z),
+    "Hadamard": np.array([[1, 1], [1, -1]]) / np.sqrt(2),
+    "CNOT": block_diag(I, X),
+    "SWAP": SWAP,
+    "CZ": block_diag(I, Z),
+    "PhaseShift": lambda phi: np.array([[1, 0], [0, np.exp(1j * phi)]]),
+    "RX": lambda phi: expm(-1j * phi / 2 * X),
+    "RY": lambda phi: expm(-1j * phi / 2 * Y),
+    "RZ": lambda phi: expm(-1j * phi / 2 * Z),
+    "Rot": lambda a, b, c: expm(-1j * c / 2 * Z) @ expm(-1j * b / 2 * Y) @ expm(-1j * a / 2 * Z),
     # arbitrary unitaries
-    'Hermitian': H,
-    'QubitUnitary': U,
+    "Hermitian": H,
+    "QubitUnitary": U,
     # the following gates are provided by the PL-Forest plugin
-    'S': np.array([[1, 0], [0, 1j]]),
-    'T': np.array([[1, 0], [0, np.exp(1j*np.pi/4)]]),
-    'CCNOT': block_diag(I, I, I, X),
-    'CPHASE': controlled_phase,
-    'CSWAP': block_diag(I, I, SWAP),
-    'ISWAP': np.array([[1, 0, 0, 0], [0, 0, 1j, 0], [0, 1j, 0, 0], [0, 0, 0, 1]]),
-    'PSWAP': lambda phi: np.array([[1, 0, 0, 0], [0, 0, np.exp(1j*phi), 0], [0, np.exp(1j*phi), 0, 0], [0, 0, 0, 1]]),
+    "S": np.array([[1, 0], [0, 1j]]),
+    "T": np.array([[1, 0], [0, np.exp(1j * np.pi / 4)]]),
+    "CCNOT": block_diag(I, I, I, X),
+    "CPHASE": controlled_phase,
+    "CSWAP": block_diag(I, I, SWAP),
+    "ISWAP": np.array([[1, 0, 0, 0], [0, 0, 1j, 0], [0, 1j, 0, 0], [0, 0, 0, 1]]),
+    "PSWAP": lambda phi: np.array(
+        [[1, 0, 0, 0], [0, 0, np.exp(1j * phi), 0], [0, np.exp(1j * phi), 0, 0], [0, 0, 0, 1]]
+    ),
 }
 
 
 # command line arguments
 def cmd_args(parser):
     """Command line argument parser"""
-    parser.addoption('-t', '--tol', type=float, help='Numerical tolerance for equality tests.')
+    parser.addoption("-t", "--tol", type=float, help="Numerical tolerance for equality tests.")
 
 
 @pytest.fixture
@@ -114,6 +116,7 @@ def shots():
 @pytest.fixture
 def apply_unitary():
     """Apply a unitary operation to the ground state."""
+
     def _apply_unitary(mat, num_wires):
         """Applies a unitary to the first wire of a register in the ground state
 
@@ -135,7 +138,7 @@ def apply_unitary():
     return _apply_unitary
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def qvm():
     try:
         qvm = QVMConnection(random_seed=52)
@@ -145,11 +148,11 @@ def qvm():
         return pytest.skip("This test requires QVM connection: {}".format(e))
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def compiler():
     try:
         config = PyquilConfig()
-        device = get_qc('3q-qvm').device
+        device = get_qc("3q-qvm").device
         compiler = QVMCompiler(endpoint=config.quilc_url, device=device)
         compiler.quil_to_native_quil(Program(Id(0)))
         return compiler
@@ -159,6 +162,7 @@ def compiler():
 
 class BaseTest:
     """Default base test class"""
+
     # pylint: disable=no-self-use
 
     def assertEqual(self, first, second):
@@ -185,14 +189,16 @@ class BaseTest:
             # check each element of the tuple separately (needed for when the tuple elements are themselves batches)
             if np.all([np.all(first[idx] == second[idx]) for idx, _ in enumerate(first)]):
                 return
-            if np.all([np.all(np.abs(first[idx] - second[idx])) <= delta for idx, _ in enumerate(first)]):
+            if np.all(
+                [np.all(np.abs(first[idx] - second[idx])) <= delta for idx, _ in enumerate(first)]
+            ):
                 return
         else:
             if np.all(first == second):
                 return
             if np.all(np.abs(first - second) <= delta):
                 return
-        assert False, '{} != {} within {} delta'.format(first, second, delta)
+        assert False, "{} != {} within {} delta".format(first, second, delta)
 
     def assertAllEqual(self, first, second):
         """

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -12,9 +12,9 @@ def test_simulator_qvm_default_agree(tol, qvm, compiler):
     on the calculation of quantum gradients."""
     w = 2
 
-    dev1 = qml.device('default.qubit', wires=w)
-    dev2 = qml.device('forest.wavefunction', wires=w)
-    dev3 = qml.device('forest.qvm', device='9q-square-qvm', shots=5000)
+    dev1 = qml.device("default.qubit", wires=w)
+    dev2 = qml.device("forest.wavefunction", wires=w)
+    dev3 = qml.device("forest.qvm", device="9q-square-qvm", shots=5000)
 
     in_state = np.zeros([w])
     in_state[0] = 1
@@ -57,8 +57,8 @@ def test_gradient_with_custom_operator(qvm, compiler):
     operator is used."""
     w = 9
 
-    dev2 = qml.device('forest.wavefunction', wires=w)
-    dev3 = qml.device('forest.qvm', device='9q-square-qvm', shots=5000)
+    dev2 = qml.device("forest.wavefunction", wires=w)
+    dev3 = qml.device("forest.qvm", device="9q-square-qvm", shots=5000)
 
     def func(x, y):
         """Reference QNode"""

--- a/tests/test_numpy_wavefunction.py
+++ b/tests/test_numpy_wavefunction.py
@@ -135,6 +135,44 @@ class TestWavefunctionBasic(BaseTest):
         # verify the device is now in the expected state
         self.assertAllAlmostEqual(res, expected_out, delta=tol)
 
+    def test_var(self, tol):
+        """Tests for variance calculation"""
+        dev = plf.NumpyWavefunctionDevice(wires=2)
+        dev.active_wires = {0}
+
+        phi = 0.543
+        theta = 0.6543
+
+        # test correct variance for <Z> of a rotated state
+        dev.apply('RX', wires=[0], par=[phi])
+        dev.apply('RY', wires=[0], par=[theta])
+        dev.pre_measure()
+
+        var = dev.var('PauliZ', [0], [])
+        expected = 0.25*(3-np.cos(2*theta)-2*np.cos(theta)**2*np.cos(2*phi))
+
+        self.assertAlmostEqual(var, expected, delta=tol)
+
+    def test_var_hermitian(self, tol):
+        """Tests for variance calculation using an arbitrary Hermitian observable"""
+        dev = plf.NumpyWavefunctionDevice(wires=2)
+        dev.active_wires = {0}
+
+        phi = 0.543
+        theta = 0.6543
+
+        # test correct variance for <H> of a rotated state
+        H = np.array([[4, -1+6j], [-1-6j, 2]])
+        dev.apply('RX', wires=[0], par=[phi])
+        dev.apply('RY', wires=[0], par=[theta])
+        dev.pre_measure()
+
+        var = dev.var('Hermitian', [0], [H])
+        expected = 0.5*(2*np.sin(2*theta)*np.cos(phi)**2+24*np.sin(phi)\
+                    *np.cos(phi)*(np.sin(theta)-np.cos(theta))+35*np.cos(2*phi)+39)
+
+        self.assertAlmostEqual(var, expected, delta=tol)
+
     @pytest.mark.parametrize("gate", plf.NumpyWavefunctionDevice._operation_map) #pylint: disable=protected-access
     def test_apply(self, gate, apply_unitary, tol):
         """Test the application of gates to a state"""

--- a/tests/test_numpy_wavefunction.py
+++ b/tests/test_numpy_wavefunction.py
@@ -65,7 +65,9 @@ class TestWavefunctionBasic(BaseTest):
         self.assertAllAlmostEqual(res, expected, delta=tol)
 
         # test exception raised if unphysical subsystems provided
-        with pytest.raises(ValueError, match="Invalid target subsystems provided in 'wires' argument."):
+        with pytest.raises(
+            ValueError, match="Invalid target subsystems provided in 'wires' argument."
+        ):
             dev.expand(U2, [-1, 5])
 
         # test exception raised if incorrect sized matrix provided
@@ -88,12 +90,16 @@ class TestWavefunctionBasic(BaseTest):
 
         # test applied to wire 0,2,3
         res = dev.expand(U_toffoli, [0, 2, 3])
-        expected = np.kron(SWAP, np.kron(I, I)) @ np.kron(I, U_toffoli) @ np.kron(SWAP, np.kron(I, I))
+        expected = (
+            np.kron(SWAP, np.kron(I, I)) @ np.kron(I, U_toffoli) @ np.kron(SWAP, np.kron(I, I))
+        )
         self.assertAllAlmostEqual(res, expected, delta=tol)
 
         # test applied to wire 0,1,3
         res = dev.expand(U_toffoli, [0, 1, 3])
-        expected = np.kron(np.kron(I, I), SWAP) @ np.kron(U_toffoli, I) @ np.kron(np.kron(I, I), SWAP)
+        expected = (
+            np.kron(np.kron(I, I), SWAP) @ np.kron(U_toffoli, I) @ np.kron(np.kron(I, I), SWAP)
+        )
         self.assertAllAlmostEqual(res, expected, delta=tol)
 
         # test applied to wire 3, 1, 2
@@ -107,7 +113,11 @@ class TestWavefunctionBasic(BaseTest):
         res = dev.expand(U_toffoli, [3, 0, 2])
         # change the control qubit on the Toffoli gate
         rows = np.array([0, 4, 1, 5, 2, 6, 3, 7])
-        expected = np.kron(SWAP, np.kron(I, I)) @ np.kron(I, U_toffoli[:, rows][rows]) @ np.kron(SWAP, np.kron(I, I))
+        expected = (
+            np.kron(SWAP, np.kron(I, I))
+            @ np.kron(I, U_toffoli[:, rows][rows])
+            @ np.kron(SWAP, np.kron(I, I))
+        )
         self.assertAllAlmostEqual(res, expected, delta=tol)
 
     @pytest.mark.parametrize("ev", plf.NumpyWavefunctionDevice.observables)
@@ -116,7 +126,7 @@ class TestWavefunctionBasic(BaseTest):
         dev = plf.NumpyWavefunctionDevice(wires=2)
 
         # start in the following initial state
-        dev.state = np.array([1, 0, 1, 1])/np.sqrt(3)
+        dev.state = np.array([1, 0, 1, 1]) / np.sqrt(3)
         dev.active_wires = {0, 1}
 
         # get the equivalent pennylane operation class
@@ -144,12 +154,12 @@ class TestWavefunctionBasic(BaseTest):
         theta = 0.6543
 
         # test correct variance for <Z> of a rotated state
-        dev.apply('RX', wires=[0], par=[phi])
-        dev.apply('RY', wires=[0], par=[theta])
+        dev.apply("RX", wires=[0], par=[phi])
+        dev.apply("RY", wires=[0], par=[theta])
         dev.pre_measure()
 
-        var = dev.var('PauliZ', [0], [])
-        expected = 0.25*(3-np.cos(2*theta)-2*np.cos(theta)**2*np.cos(2*phi))
+        var = dev.var("PauliZ", [0], [])
+        expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
 
         self.assertAlmostEqual(var, expected, delta=tol)
 
@@ -162,18 +172,24 @@ class TestWavefunctionBasic(BaseTest):
         theta = 0.6543
 
         # test correct variance for <H> of a rotated state
-        H = np.array([[4, -1+6j], [-1-6j, 2]])
-        dev.apply('RX', wires=[0], par=[phi])
-        dev.apply('RY', wires=[0], par=[theta])
+        H = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        dev.apply("RX", wires=[0], par=[phi])
+        dev.apply("RY", wires=[0], par=[theta])
         dev.pre_measure()
 
-        var = dev.var('Hermitian', [0], [H])
-        expected = 0.5*(2*np.sin(2*theta)*np.cos(phi)**2+24*np.sin(phi)\
-                    *np.cos(phi)*(np.sin(theta)-np.cos(theta))+35*np.cos(2*phi)+39)
+        var = dev.var("Hermitian", [0], [H])
+        expected = 0.5 * (
+            2 * np.sin(2 * theta) * np.cos(phi) ** 2
+            + 24 * np.sin(phi) * np.cos(phi) * (np.sin(theta) - np.cos(theta))
+            + 35 * np.cos(2 * phi)
+            + 39
+        )
 
         self.assertAlmostEqual(var, expected, delta=tol)
 
-    @pytest.mark.parametrize("gate", plf.NumpyWavefunctionDevice._operation_map) #pylint: disable=protected-access
+    @pytest.mark.parametrize(
+        "gate", plf.NumpyWavefunctionDevice._operation_map
+    )  # pylint: disable=protected-access
     def test_apply(self, gate, apply_unitary, tol):
         """Test the application of gates to a state"""
         dev = plf.NumpyWavefunctionDevice(wires=3)
@@ -188,17 +204,17 @@ class TestWavefunctionBasic(BaseTest):
         # the list of wires to apply the operation to
         w = list(range(op.num_wires))
 
-        if op.par_domain == 'A':
+        if op.par_domain == "A":
             # the parameter is an array
-            if gate == 'QubitUnitary':
+            if gate == "QubitUnitary":
                 p = [U]
                 w = [0]
                 expected_out = apply_unitary(U, 3)
-            elif gate == 'BasisState':
+            elif gate == "BasisState":
                 p = [np.array([1, 1, 1])]
                 expected_out = np.array([0, 0, 0, 0, 0, 0, 0, 1])
         else:
-            p = [0.432423, 2, 0.324][:op.num_params]
+            p = [0.432423, 2, 0.324][: op.num_params]
             fn = test_operation_map[gate]
 
             if callable(fn):
@@ -221,18 +237,19 @@ class TestWavefunctionBasic(BaseTest):
 
 class TestWavefunctionIntegration(BaseTest):
     """Test the NumPy wavefunction simulator works correctly from the PennyLane frontend."""
+
     # pylint:disable=no-self-use
 
     def test_load_wavefunction_device(self):
         """Test that the wavefunction device loads correctly"""
-        dev = qml.device('forest.numpy_wavefunction', wires=2)
+        dev = qml.device("forest.numpy_wavefunction", wires=2)
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.shots, 0)
-        self.assertEqual(dev.short_name, 'forest.numpy_wavefunction')
+        self.assertEqual(dev.short_name, "forest.numpy_wavefunction")
 
     def test_program_property(self):
         """Test that the program property works as expected"""
-        dev = qml.device('forest.numpy_wavefunction', wires=2)
+        dev = qml.device("forest.numpy_wavefunction", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -246,16 +263,16 @@ class TestWavefunctionIntegration(BaseTest):
         # construct and run the program
         circuit()
         self.assertEqual(len(dev.program), 2)
-        self.assertEqual(str(dev.program), 'H 0\nY 0\n')
+        self.assertEqual(str(dev.program), "H 0\nY 0\n")
 
     def test_wavefunction_args(self):
         """Test that the wavefunction plugin requires correct arguments"""
         with pytest.raises(TypeError, match="missing 1 required positional argument: 'wires'"):
-            qml.device('forest.numpy_wavefunction')
+            qml.device("forest.numpy_wavefunction")
 
     def test_hermitian_expectation(self, tol):
         """Test that an arbitrary Hermitian expectation value works"""
-        dev = qml.device('forest.numpy_wavefunction', wires=1)
+        dev = qml.device("forest.numpy_wavefunction", wires=1)
 
         @qml.qnode(dev)
         def circuit():
@@ -264,12 +281,12 @@ class TestWavefunctionIntegration(BaseTest):
             qml.PauliY(wires=0)
             return qml.expval(qml.Hermitian(H, 0))
 
-        out_state = 1j*np.array([-1, 1])/np.sqrt(2)
+        out_state = 1j * np.array([-1, 1]) / np.sqrt(2)
         self.assertAllAlmostEqual(circuit(), np.vdot(out_state, H @ out_state), delta=tol)
 
     def test_qubit_unitary(self, tol):
         """Test that an arbitrary unitary operation works"""
-        dev = qml.device('forest.numpy_wavefunction', wires=3)
+        dev = qml.device("forest.numpy_wavefunction", wires=3)
 
         @qml.qnode(dev)
         def circuit():
@@ -279,13 +296,13 @@ class TestWavefunctionIntegration(BaseTest):
             qml.QubitUnitary(U2, wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
-        out_state = U2 @ np.array([1, 0, 0, 1])/np.sqrt(2)
+        out_state = U2 @ np.array([1, 0, 0, 1]) / np.sqrt(2)
         obs = np.kron(np.array([[1, 0], [0, -1]]), I)
         self.assertAllAlmostEqual(circuit(), np.vdot(out_state, obs @ out_state), delta=tol)
 
     def test_invalid_qubit_unitary(self):
         """Test that an invalid unitary operation is not allowed"""
-        dev = qml.device('forest.numpy_wavefunction', wires=3)
+        dev = qml.device("forest.numpy_wavefunction", wires=3)
 
         def circuit(Umat):
             """Test QNode"""
@@ -306,7 +323,7 @@ class TestWavefunctionIntegration(BaseTest):
 
     def test_one_qubit_wavefunction_circuit(self, tol):
         """Test that the wavefunction plugin provides correct result for simple circuit"""
-        dev = qml.device('forest.numpy_wavefunction', wires=1)
+        dev = qml.device("forest.numpy_wavefunction", wires=1)
 
         a = 0.543
         b = 0.123
@@ -321,12 +338,12 @@ class TestWavefunctionIntegration(BaseTest):
             return qml.expval(qml.PauliZ(0))
 
         print(circuit(a, b, c))
-        self.assertAlmostEqual(circuit(a, b, c), np.cos(a)*np.sin(b), delta=tol)
+        self.assertAlmostEqual(circuit(a, b, c), np.cos(a) * np.sin(b), delta=tol)
 
     def test_two_qubit_wavefunction_circuit(self, tol):
         """Test that the wavefunction plugin provides correct result for simple 2-qubit circuit,
         even when the number of wires > number of qubits."""
-        dev = qml.device('forest.numpy_wavefunction', wires=3)
+        dev = qml.device("forest.numpy_wavefunction", wires=3)
 
         a = 0.543
         b = 0.123
@@ -344,12 +361,14 @@ class TestWavefunctionIntegration(BaseTest):
             plf.CPHASE(w, 0, wires=[0, 1])
             return qml.expval(qml.PauliY(1))
 
-        self.assertAlmostEqual(circuit(theta, a, b, c), -np.sin(b/2)**2*np.sin(2*theta), delta=tol)
+        self.assertAlmostEqual(
+            circuit(theta, a, b, c), -np.sin(b / 2) ** 2 * np.sin(2 * theta), delta=tol
+        )
 
     def test_nonzero_shots(self):
         """Test that the wavefunction plugin provides correct result for high shot number"""
-        shots = 10**2
-        dev = qml.device('forest.numpy_wavefunction', wires=1, shots=shots)
+        shots = 10 ** 2
+        dev = qml.device("forest.numpy_wavefunction", wires=1, shots=shots)
 
         a = 0.543
         b = 0.123
@@ -367,6 +386,6 @@ class TestWavefunctionIntegration(BaseTest):
         for _ in range(100):
             runs.append(circuit(a, b, c))
 
-        expected_var = np.sqrt(1/shots)
-        print(np.mean(runs), np.cos(a)*np.sin(b))
-        self.assertAlmostEqual(np.mean(runs), np.cos(a)*np.sin(b), delta=expected_var)
+        expected_var = np.sqrt(1 / shots)
+        print(np.mean(runs), np.cos(a) * np.sin(b))
+        self.assertAlmostEqual(np.mean(runs), np.cos(a) * np.sin(b), delta=expected_var)

--- a/tests/test_pyqvm.py
+++ b/tests/test_pyqvm.py
@@ -188,6 +188,52 @@ class TestPyQVMBasic(BaseTest):
 
         self.assertAllAlmostEqual(res, expected, delta=4/np.sqrt(shots))
 
+    def test_var(self, shots):
+        """Tests for variance calculation"""
+        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
+
+        phi = 0.543
+        theta = 0.6543
+
+        # test correct variance for <Z> of a rotated state
+        dev.apply('RX', wires=[0], par=[phi])
+        dev.apply('RY', wires=[0], par=[theta])
+
+        O = qml.PauliZ
+        name = 'PauliZ'
+
+        dev._obs_queue = [O(wires=[0], do_queue=False)]
+        dev.pre_measure()
+
+        var = dev.var(name, [0], [])
+        expected = 0.25*(3-np.cos(2*theta)-2*np.cos(theta)**2*np.cos(2*phi))
+
+        self.assertAlmostEqual(var, expected, delta=3/np.sqrt(shots))
+
+    def test_var_hermitian(self, shots):
+        """Tests for variance calculation using an arbitrary Hermitian observable"""
+        dev = plf.QVMDevice(device='2q-pyqvm', shots=10*shots)
+
+        phi = 0.543
+        theta = 0.6543
+
+        # test correct variance for <A> of a rotated state
+        A = np.array([[4, -1+6j], [-1-6j, 2]])
+        dev.apply('RX', wires=[0], par=[phi])
+        dev.apply('RY', wires=[0], par=[theta])
+
+        O = qml.Hermitian
+        name = 'Hermitian'
+
+        dev._obs_queue = [O(A, wires=[0], do_queue=False)]
+        dev.pre_measure()
+
+        var = dev.var('Hermitian', [0], [A])
+        expected = 0.5*(2*np.sin(2*theta)*np.cos(phi)**2+24*np.sin(phi)\
+                    *np.cos(phi)*(np.sin(theta)-np.cos(theta))+35*np.cos(2*phi)+39)
+
+        self.assertAlmostEqual(var, expected, delta=0.2)
+
     @pytest.mark.parametrize("gate", plf.QVMDevice._operation_map) #pylint: disable=protected-access
     def test_apply(self, gate, apply_unitary, shots):
         """Test the application of gates"""

--- a/tests/test_pyqvm.py
+++ b/tests/test_pyqvm.py
@@ -24,6 +24,7 @@ np.random.seed(42)
 
 class TestPyQVMBasic(BaseTest):
     """Unit tests for the pyQVM simulator."""
+
     # pylint: disable=protected-access
 
     def test_identity_expectation(self, shots):
@@ -31,13 +32,13 @@ class TestPyQVMBasic(BaseTest):
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
-        dev.apply('RX', wires=[0], par=[theta])
-        dev.apply('RX', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-pyqvm", shots=shots)
+        dev.apply("RX", wires=[0], par=[theta])
+        dev.apply("RX", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.ops.Identity
-        name = 'Identity'
+        name = "Identity"
 
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
         res = dev.pre_measure()
@@ -45,20 +46,20 @@ class TestPyQVMBasic(BaseTest):
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
 
         # below are the analytic expectation values for this circuit (trace should always be 1)
-        self.assertAllAlmostEqual(res, np.array([1, 1]), delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(res, np.array([1, 1]), delta=3 / np.sqrt(shots))
 
     def test_pauliz_expectation(self, shots):
         """Test that PauliZ expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
-        dev.apply('RX', wires=[0], par=[theta])
-        dev.apply('RX', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-pyqvm", shots=shots)
+        dev.apply("RX", wires=[0], par=[theta])
+        dev.apply("RX", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.PauliZ
-        name = 'PauliZ'
+        name = "PauliZ"
 
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
         res = dev.pre_measure()
@@ -66,81 +67,89 @@ class TestPyQVMBasic(BaseTest):
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
 
         # below are the analytic expectation values for this circuit
-        self.assertAllAlmostEqual(res, np.array([np.cos(theta), np.cos(theta)*np.cos(phi)]), delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(
+            res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), delta=3 / np.sqrt(shots)
+        )
 
     def test_paulix_expectation(self, shots):
         """Test that PauliX expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
-        dev.apply('RY', wires=[0], par=[theta])
-        dev.apply('RY', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-pyqvm", shots=shots)
+        dev.apply("RY", wires=[0], par=[theta])
+        dev.apply("RY", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.PauliX
-        name = 'PauliX'
+        name = "PauliX"
 
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
         dev.pre_measure()
 
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
         # below are the analytic expectation values for this circuit
-        self.assertAllAlmostEqual(res, np.array([np.sin(theta)*np.sin(phi), np.sin(phi)]), delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(
+            res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), delta=3 / np.sqrt(shots)
+        )
 
     def test_pauliy_expectation(self, shots):
         """Test that PauliY expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
-        dev.apply('RX', wires=[0], par=[theta])
-        dev.apply('RX', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-pyqvm", shots=shots)
+        dev.apply("RX", wires=[0], par=[theta])
+        dev.apply("RX", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.PauliY
-        name = 'PauliY'
+        name = "PauliY"
 
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
         dev.pre_measure()
 
         # below are the analytic expectation values for this circuit
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
-        self.assertAllAlmostEqual(res, np.array([0, -np.cos(theta)*np.sin(phi)]), delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(
+            res, np.array([0, -np.cos(theta) * np.sin(phi)]), delta=3 / np.sqrt(shots)
+        )
 
     def test_hadamard_expectation(self, shots):
         """Test that Hadamard expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
-        dev.apply('RY', wires=[0], par=[theta])
-        dev.apply('RY', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-pyqvm", shots=shots)
+        dev.apply("RY", wires=[0], par=[theta])
+        dev.apply("RY", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.Hadamard
-        name = 'Hadamard'
+        name = "Hadamard"
 
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
         dev.pre_measure()
 
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
         # below are the analytic expectation values for this circuit
-        expected = np.array([np.sin(theta)*np.sin(phi)+np.cos(theta), np.cos(theta)*np.cos(phi)+np.sin(phi)])/np.sqrt(2)
-        self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(shots))
+        expected = np.array(
+            [np.sin(theta) * np.sin(phi) + np.cos(theta), np.cos(theta) * np.cos(phi) + np.sin(phi)]
+        ) / np.sqrt(2)
+        self.assertAllAlmostEqual(res, expected, delta=3 / np.sqrt(shots))
 
     def test_hermitian_expectation(self, shots):
         """Test that arbitrary Hermitian expectation values are correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-pyqvm', shots=5*shots)
-        dev.apply('RY', wires=[0], par=[theta])
-        dev.apply('RY', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-pyqvm", shots=5 * shots)
+        dev.apply("RY", wires=[0], par=[theta])
+        dev.apply("RY", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.Hermitian
-        name = 'Hermitian'
+        name = "Hermitian"
 
         dev._obs_queue = [O(H, wires=[0], do_queue=False), O(H, wires=[1], do_queue=False)]
         dev.pre_measure()
@@ -152,29 +161,33 @@ class TestPyQVMBasic(BaseTest):
         a = H[0, 0]
         re_b = H[0, 1].real
         d = H[1, 1]
-        ev1 = ((a-d)*np.cos(theta)+2*re_b*np.sin(theta)*np.sin(phi)+a+d)/2
-        ev2 = ((a-d)*np.cos(theta)*np.cos(phi)+2*re_b*np.sin(phi)+a+d)/2
+        ev1 = ((a - d) * np.cos(theta) + 2 * re_b * np.sin(theta) * np.sin(phi) + a + d) / 2
+        ev2 = ((a - d) * np.cos(theta) * np.cos(phi) + 2 * re_b * np.sin(phi) + a + d) / 2
         expected = np.array([ev1, ev2])
 
-        self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(res, expected, delta=3 / np.sqrt(shots))
 
     def test_multi_mode_hermitian_expectation(self, shots, qvm, compiler):
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
         theta = np.random.random()
         phi = np.random.random()
 
-        dev = plf.QVMDevice(device='2q-pyqvm', shots=10*shots)
-        dev.apply('RY', wires=[0], par=[theta])
-        dev.apply('RY', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-pyqvm", shots=10 * shots)
+        dev.apply("RY", wires=[0], par=[theta])
+        dev.apply("RY", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.Hermitian
-        name = 'Hermitian'
+        name = "Hermitian"
 
-        A = np.array([[-6, 2+1j, -3, -5+2j],
-                      [2-1j, 0, 2-1j, -5+4j],
-                      [-3, 2+1j, 0, -4+3j],
-                      [-5-2j, -5-4j, -4-3j, -6]])
+        A = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
 
         dev._obs_queue = [O(A, wires=[0, 1], do_queue=False)]
         dev.pre_measure()
@@ -183,61 +196,72 @@ class TestPyQVMBasic(BaseTest):
 
         # below is the analytic expectation value for this circuit with arbitrary
         # Hermitian observable A
-        expected = 0.5*(6*np.cos(theta)*np.sin(phi)-np.sin(theta)*(8*np.sin(phi)+7*np.cos(phi)+3) \
-                    -2*np.sin(phi)-6*np.cos(phi)-6)
+        expected = 0.5 * (
+            6 * np.cos(theta) * np.sin(phi)
+            - np.sin(theta) * (8 * np.sin(phi) + 7 * np.cos(phi) + 3)
+            - 2 * np.sin(phi)
+            - 6 * np.cos(phi)
+            - 6
+        )
 
-        self.assertAllAlmostEqual(res, expected, delta=4/np.sqrt(shots))
+        self.assertAllAlmostEqual(res, expected, delta=4 / np.sqrt(shots))
 
     def test_var(self, shots):
         """Tests for variance calculation"""
-        dev = plf.QVMDevice(device='2q-pyqvm', shots=shots)
+        dev = plf.QVMDevice(device="2q-pyqvm", shots=shots)
 
         phi = 0.543
         theta = 0.6543
 
         # test correct variance for <Z> of a rotated state
-        dev.apply('RX', wires=[0], par=[phi])
-        dev.apply('RY', wires=[0], par=[theta])
+        dev.apply("RX", wires=[0], par=[phi])
+        dev.apply("RY", wires=[0], par=[theta])
 
         O = qml.PauliZ
-        name = 'PauliZ'
+        name = "PauliZ"
 
         dev._obs_queue = [O(wires=[0], do_queue=False)]
         dev.pre_measure()
 
         var = dev.var(name, [0], [])
-        expected = 0.25*(3-np.cos(2*theta)-2*np.cos(theta)**2*np.cos(2*phi))
+        expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
 
-        self.assertAlmostEqual(var, expected, delta=3/np.sqrt(shots))
+        self.assertAlmostEqual(var, expected, delta=3 / np.sqrt(shots))
 
     def test_var_hermitian(self, shots):
         """Tests for variance calculation using an arbitrary Hermitian observable"""
-        dev = plf.QVMDevice(device='2q-pyqvm', shots=10*shots)
+        dev = plf.QVMDevice(device="2q-pyqvm", shots=10 * shots)
 
         phi = 0.543
         theta = 0.6543
 
         # test correct variance for <A> of a rotated state
-        A = np.array([[4, -1+6j], [-1-6j, 2]])
-        dev.apply('RX', wires=[0], par=[phi])
-        dev.apply('RY', wires=[0], par=[theta])
+        A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        dev.apply("RX", wires=[0], par=[phi])
+        dev.apply("RY", wires=[0], par=[theta])
 
         O = qml.Hermitian
-        name = 'Hermitian'
+        name = "Hermitian"
 
         dev._obs_queue = [O(A, wires=[0], do_queue=False)]
         dev.pre_measure()
 
-        var = dev.var('Hermitian', [0], [A])
-        expected = 0.5*(2*np.sin(2*theta)*np.cos(phi)**2+24*np.sin(phi)\
-                    *np.cos(phi)*(np.sin(theta)-np.cos(theta))+35*np.cos(2*phi)+39)
+        var = dev.var("Hermitian", [0], [A])
+        expected = 0.5 * (
+            2 * np.sin(2 * theta) * np.cos(phi) ** 2
+            + 24 * np.sin(phi) * np.cos(phi) * (np.sin(theta) - np.cos(theta))
+            + 35 * np.cos(2 * phi)
+            + 39
+        )
 
         self.assertAlmostEqual(var, expected, delta=0.2)
 
-    @pytest.mark.parametrize("gate", plf.QVMDevice._operation_map) #pylint: disable=protected-access
+    @pytest.mark.parametrize(
+        "gate", plf.QVMDevice._operation_map
+    )  # pylint: disable=protected-access
     def test_apply(self, gate, apply_unitary, shots):
         """Test the application of gates"""
-        dev = plf.QVMDevice(device='3q-pyqvm', shots=shots)
+        dev = plf.QVMDevice(device="3q-pyqvm", shots=shots)
 
         try:
             # get the equivalent pennylane operation class
@@ -249,17 +273,17 @@ class TestPyQVMBasic(BaseTest):
         # the list of wires to apply the operation to
         w = list(range(op.num_wires))
 
-        if op.par_domain == 'A':
+        if op.par_domain == "A":
             # the parameter is an array
-            if gate == 'QubitUnitary':
+            if gate == "QubitUnitary":
                 p = [U]
                 w = [0]
                 state = apply_unitary(U, 3)
-            elif gate == 'BasisState':
+            elif gate == "BasisState":
                 p = [np.array([1, 1, 1])]
                 state = np.array([0, 0, 0, 0, 0, 0, 0, 1])
         else:
-            p = [0.432423, 2, 0.324][:op.num_params]
+            p = [0.432423, 2, 0.324][: op.num_params]
             fn = test_operation_map[gate]
 
             if callable(fn):
@@ -277,23 +301,24 @@ class TestPyQVMBasic(BaseTest):
         dev._obs_queue = []
         dev.pre_measure()
 
-        res = dev.expval('PauliZ', wires=[0], par=None)
+        res = dev.expval("PauliZ", wires=[0], par=None)
         expected = np.vdot(state, np.kron(np.kron(Z, I), I) @ state)
 
         # verify the device is now in the expected state
         # Note we have increased the tolerance here, since we are only
         # performing 1024 shots.
-        self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(res, expected, delta=3 / np.sqrt(shots))
 
 
 class TestQVMIntegration(BaseTest):
     """Test the pyQVM simulator works correctly from the PennyLane frontend."""
-    #pylint: disable=no-self-use
+
+    # pylint: disable=no-self-use
 
     def test_qubit_unitary(self, shots):
         """Test that an arbitrary unitary operation works"""
-        dev1 = qml.device('forest.qvm', device='3q-pyqvm', shots=shots)
-        dev2 = qml.device('forest.qvm', device='9q-square-pyqvm', shots=shots)
+        dev1 = qml.device("forest.qvm", device="3q-pyqvm", shots=shots)
+        dev2 = qml.device("forest.qvm", device="9q-square-pyqvm", shots=shots)
 
         def circuit():
             """Reference QNode"""
@@ -305,17 +330,21 @@ class TestQVMIntegration(BaseTest):
         circuit1 = qml.QNode(circuit, dev1)
         circuit2 = qml.QNode(circuit, dev2)
 
-        out_state = U2 @ np.array([1, 0, 0, 1])/np.sqrt(2)
+        out_state = U2 @ np.array([1, 0, 0, 1]) / np.sqrt(2)
         obs = np.kron(np.array([[1, 0], [0, -1]]), I)
 
-        self.assertAllAlmostEqual(circuit1(), np.vdot(out_state, obs @ out_state), delta=3/np.sqrt(shots))
-        self.assertAllAlmostEqual(circuit2(), np.vdot(out_state, obs @ out_state), delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(
+            circuit1(), np.vdot(out_state, obs @ out_state), delta=3 / np.sqrt(shots)
+        )
+        self.assertAllAlmostEqual(
+            circuit2(), np.vdot(out_state, obs @ out_state), delta=3 / np.sqrt(shots)
+        )
 
-    @pytest.mark.parametrize('device', ['2q-pyqvm'])
+    @pytest.mark.parametrize("device", ["2q-pyqvm"])
     def test_one_qubit_wavefunction_circuit(self, device):
         """Test that the wavefunction plugin provides correct result for simple circuit"""
         shots = 100000
-        dev = qml.device('forest.qvm', device=device, shots=shots)
+        dev = qml.device("forest.qvm", device=device, shots=shots)
 
         a = 0.543
         b = 0.123
@@ -329,4 +358,4 @@ class TestQVMIntegration(BaseTest):
             qml.Rot(x, y, z, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        self.assertAlmostEqual(circuit(a, b, c), np.cos(a)*np.sin(b), delta=3/np.sqrt(shots))
+        self.assertAlmostEqual(circuit(a, b, c), np.cos(a) * np.sin(b), delta=3 / np.sqrt(shots))

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -15,26 +15,27 @@ log = logging.getLogger(__name__)
 
 class TestQPUIntegration(BaseTest):
     """Test the wavefunction simulator works correctly from the PennyLane frontend."""
-    #pylint: disable=no-self-use
+
+    # pylint: disable=no-self-use
 
     def test_load_qpu_device(self):
         """Test that the QPU device loads correctly"""
-        dev = qml.device('forest.qpu', device='Aspen-1-2Q-B', load_qc=False)
+        dev = qml.device("forest.qpu", device="Aspen-1-2Q-B", load_qc=False)
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.shots, 1024)
-        self.assertEqual(dev.short_name, 'forest.qpu')
+        self.assertEqual(dev.short_name, "forest.qpu")
 
     def test_load_virtual_qpu_device(self):
         """Test that the QPU simulators load correctly"""
-        qml.device('forest.qpu', device='Aspen-1-2Q-B', load_qc=False)
+        qml.device("forest.qpu", device="Aspen-1-2Q-B", load_qc=False)
 
     def test_qpu_args(self):
         """Test that the QPU plugin requires correct arguments"""
         with pytest.raises(ValueError, match="QPU device does not support a wires parameter"):
-            qml.device('forest.qpu', device='Aspen-1-7Q-B', wires=2)
+            qml.device("forest.qpu", device="Aspen-1-7Q-B", wires=2)
 
         with pytest.raises(TypeError, match="missing 1 required positional argument"):
-            qml.device('forest.qpu')
+            qml.device("forest.qpu")
 
         with pytest.raises(ValueError, match="Number of shots must be a positive integer"):
-            qml.device('forest.qpu', 'Aspen-1-7Q-B', shots=0)
+            qml.device("forest.qpu", "Aspen-1-7Q-B", shots=0)

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -19,11 +19,12 @@ import pyquil
 
 log = logging.getLogger(__name__)
 
-VALID_QPU_LATTICES = [qc for qc in pyquil.list_quantum_computers() if 'qvm' not in qc]
+VALID_QPU_LATTICES = [qc for qc in pyquil.list_quantum_computers() if "qvm" not in qc]
 
 
 class TestQVMBasic(BaseTest):
     """Unit tests for the QVM simulator."""
+
     # pylint: disable=protected-access
 
     def test_identity_expectation(self, shots, qvm, compiler):
@@ -31,13 +32,13 @@ class TestQVMBasic(BaseTest):
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
-        dev.apply('RX', wires=[0], par=[theta])
-        dev.apply('RX', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-qvm", shots=shots)
+        dev.apply("RX", wires=[0], par=[theta])
+        dev.apply("RX", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.Identity
-        name = 'Identity'
+        name = "Identity"
 
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
         res = dev.pre_measure()
@@ -45,20 +46,20 @@ class TestQVMBasic(BaseTest):
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
 
         # below are the analytic expectation values for this circuit (trace should always be 1)
-        self.assertAllAlmostEqual(res, np.array([1, 1]), delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(res, np.array([1, 1]), delta=3 / np.sqrt(shots))
 
     def test_pauliz_expectation(self, shots, qvm, compiler):
         """Test that PauliZ expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
-        dev.apply('RX', wires=[0], par=[theta])
-        dev.apply('RX', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-qvm", shots=shots)
+        dev.apply("RX", wires=[0], par=[theta])
+        dev.apply("RX", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.PauliZ
-        name = 'PauliZ'
+        name = "PauliZ"
 
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
         res = dev.pre_measure()
@@ -66,81 +67,89 @@ class TestQVMBasic(BaseTest):
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
 
         # below are the analytic expectation values for this circuit
-        self.assertAllAlmostEqual(res, np.array([np.cos(theta), np.cos(theta)*np.cos(phi)]), delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(
+            res, np.array([np.cos(theta), np.cos(theta) * np.cos(phi)]), delta=3 / np.sqrt(shots)
+        )
 
     def test_paulix_expectation(self, shots, qvm, compiler):
         """Test that PauliX expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
-        dev.apply('RY', wires=[0], par=[theta])
-        dev.apply('RY', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-qvm", shots=shots)
+        dev.apply("RY", wires=[0], par=[theta])
+        dev.apply("RY", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.PauliX
-        name = 'PauliX'
+        name = "PauliX"
 
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
         dev.pre_measure()
 
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
         # below are the analytic expectation values for this circuit
-        self.assertAllAlmostEqual(res, np.array([np.sin(theta)*np.sin(phi), np.sin(phi)]), delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(
+            res, np.array([np.sin(theta) * np.sin(phi), np.sin(phi)]), delta=3 / np.sqrt(shots)
+        )
 
     def test_pauliy_expectation(self, shots, qvm, compiler):
         """Test that PauliY expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
-        dev.apply('RX', wires=[0], par=[theta])
-        dev.apply('RX', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-qvm", shots=shots)
+        dev.apply("RX", wires=[0], par=[theta])
+        dev.apply("RX", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.PauliY
-        name = 'PauliY'
+        name = "PauliY"
 
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
         dev.pre_measure()
 
         # below are the analytic expectation values for this circuit
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
-        self.assertAllAlmostEqual(res, np.array([0, -np.cos(theta)*np.sin(phi)]), delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(
+            res, np.array([0, -np.cos(theta) * np.sin(phi)]), delta=3 / np.sqrt(shots)
+        )
 
     def test_hadamard_expectation(self, shots, qvm, compiler):
         """Test that Hadamard expectation value is correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
-        dev.apply('RY', wires=[0], par=[theta])
-        dev.apply('RY', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-qvm", shots=shots)
+        dev.apply("RY", wires=[0], par=[theta])
+        dev.apply("RY", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.Hadamard
-        name = 'Hadamard'
+        name = "Hadamard"
 
         dev._obs_queue = [O(wires=[0], do_queue=False), O(wires=[1], do_queue=False)]
         dev.pre_measure()
 
         res = np.array([dev.expval(name, [0], []), dev.expval(name, [1], [])])
         # below are the analytic expectation values for this circuit
-        expected = np.array([np.sin(theta)*np.sin(phi)+np.cos(theta), np.cos(theta)*np.cos(phi)+np.sin(phi)])/np.sqrt(2)
-        self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(shots))
+        expected = np.array(
+            [np.sin(theta) * np.sin(phi) + np.cos(theta), np.cos(theta) * np.cos(phi) + np.sin(phi)]
+        ) / np.sqrt(2)
+        self.assertAllAlmostEqual(res, expected, delta=3 / np.sqrt(shots))
 
     def test_hermitian_expectation(self, shots, qvm, compiler):
         """Test that arbitrary Hermitian expectation values are correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
-        dev.apply('RY', wires=[0], par=[theta])
-        dev.apply('RY', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-qvm", shots=shots)
+        dev.apply("RY", wires=[0], par=[theta])
+        dev.apply("RY", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.Hermitian
-        name = 'Hermitian'
+        name = "Hermitian"
 
         dev._obs_queue = [O(H, wires=[0], do_queue=False), O(H, wires=[1], do_queue=False)]
         dev.pre_measure()
@@ -152,29 +161,33 @@ class TestQVMBasic(BaseTest):
         a = H[0, 0]
         re_b = H[0, 1].real
         d = H[1, 1]
-        ev1 = ((a-d)*np.cos(theta)+2*re_b*np.sin(theta)*np.sin(phi)+a+d)/2
-        ev2 = ((a-d)*np.cos(theta)*np.cos(phi)+2*re_b*np.sin(phi)+a+d)/2
+        ev1 = ((a - d) * np.cos(theta) + 2 * re_b * np.sin(theta) * np.sin(phi) + a + d) / 2
+        ev2 = ((a - d) * np.cos(theta) * np.cos(phi) + 2 * re_b * np.sin(phi) + a + d) / 2
         expected = np.array([ev1, ev2])
 
-        self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(res, expected, delta=3 / np.sqrt(shots))
 
     def test_multi_mode_hermitian_expectation(self, shots, qvm, compiler):
         """Test that arbitrary multi-mode Hermitian expectation values are correct"""
         theta = 0.432
         phi = 0.123
 
-        dev = plf.QVMDevice(device='2q-qvm', shots=10*shots)
-        dev.apply('RY', wires=[0], par=[theta])
-        dev.apply('RY', wires=[1], par=[phi])
-        dev.apply('CNOT', wires=[0, 1], par=[])
+        dev = plf.QVMDevice(device="2q-qvm", shots=10 * shots)
+        dev.apply("RY", wires=[0], par=[theta])
+        dev.apply("RY", wires=[1], par=[phi])
+        dev.apply("CNOT", wires=[0, 1], par=[])
 
         O = qml.Hermitian
-        name = 'Hermitian'
+        name = "Hermitian"
 
-        A = np.array([[-6, 2+1j, -3, -5+2j],
-                      [2-1j, 0, 2-1j, -5+4j],
-                      [-3, 2+1j, 0, -4+3j],
-                      [-5-2j, -5-4j, -4-3j, -6]])
+        A = np.array(
+            [
+                [-6, 2 + 1j, -3, -5 + 2j],
+                [2 - 1j, 0, 2 - 1j, -5 + 4j],
+                [-3, 2 + 1j, 0, -4 + 3j],
+                [-5 - 2j, -5 - 4j, -4 - 3j, -6],
+            ]
+        )
 
         dev._obs_queue = [O(A, wires=[0, 1], do_queue=False)]
         dev.pre_measure()
@@ -183,61 +196,72 @@ class TestQVMBasic(BaseTest):
 
         # below is the analytic expectation value for this circuit with arbitrary
         # Hermitian observable A
-        expected = 0.5*(6*np.cos(theta)*np.sin(phi)-np.sin(theta)*(8*np.sin(phi)+7*np.cos(phi)+3) \
-                    -2*np.sin(phi)-6*np.cos(phi)-6)
+        expected = 0.5 * (
+            6 * np.cos(theta) * np.sin(phi)
+            - np.sin(theta) * (8 * np.sin(phi) + 7 * np.cos(phi) + 3)
+            - 2 * np.sin(phi)
+            - 6 * np.cos(phi)
+            - 6
+        )
 
-        self.assertAllAlmostEqual(res, expected, delta=4/np.sqrt(shots))
+        self.assertAllAlmostEqual(res, expected, delta=4 / np.sqrt(shots))
 
     def test_var(self, shots):
         """Tests for variance calculation"""
-        dev = plf.QVMDevice(device='2q-qvm', shots=shots)
+        dev = plf.QVMDevice(device="2q-qvm", shots=shots)
 
         phi = 0.543
         theta = 0.6543
 
         # test correct variance for <Z> of a rotated state
-        dev.apply('RX', wires=[0], par=[phi])
-        dev.apply('RY', wires=[0], par=[theta])
+        dev.apply("RX", wires=[0], par=[phi])
+        dev.apply("RY", wires=[0], par=[theta])
 
         O = qml.PauliZ
-        name = 'PauliZ'
+        name = "PauliZ"
 
         dev._obs_queue = [O(wires=[0], do_queue=False)]
         dev.pre_measure()
 
         var = dev.var(name, [0], [])
-        expected = 0.25*(3-np.cos(2*theta)-2*np.cos(theta)**2*np.cos(2*phi))
+        expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
 
-        self.assertAlmostEqual(var, expected, delta=3/np.sqrt(shots))
+        self.assertAlmostEqual(var, expected, delta=3 / np.sqrt(shots))
 
     def test_var_hermitian(self, shots):
         """Tests for variance calculation using an arbitrary Hermitian observable"""
-        dev = plf.QVMDevice(device='2q-qvm', shots=10*shots)
+        dev = plf.QVMDevice(device="2q-qvm", shots=10 * shots)
 
         phi = 0.543
         theta = 0.6543
 
         # test correct variance for <A> of a rotated state
-        A = np.array([[4, -1+6j], [-1-6j, 2]])
-        dev.apply('RX', wires=[0], par=[phi])
-        dev.apply('RY', wires=[0], par=[theta])
+        A = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        dev.apply("RX", wires=[0], par=[phi])
+        dev.apply("RY", wires=[0], par=[theta])
 
         O = qml.Hermitian
-        name = 'Hermitian'
+        name = "Hermitian"
 
         dev._obs_queue = [O(A, wires=[0], do_queue=False)]
         dev.pre_measure()
 
-        var = dev.var('Hermitian', [0], [A])
-        expected = 0.5*(2*np.sin(2*theta)*np.cos(phi)**2+24*np.sin(phi)\
-                    *np.cos(phi)*(np.sin(theta)-np.cos(theta))+35*np.cos(2*phi)+39)
+        var = dev.var("Hermitian", [0], [A])
+        expected = 0.5 * (
+            2 * np.sin(2 * theta) * np.cos(phi) ** 2
+            + 24 * np.sin(phi) * np.cos(phi) * (np.sin(theta) - np.cos(theta))
+            + 35 * np.cos(2 * phi)
+            + 39
+        )
 
         self.assertAlmostEqual(var, expected, delta=0.2)
 
-    @pytest.mark.parametrize("gate", plf.QVMDevice._operation_map) #pylint: disable=protected-access
+    @pytest.mark.parametrize(
+        "gate", plf.QVMDevice._operation_map
+    )  # pylint: disable=protected-access
     def test_apply(self, gate, apply_unitary, shots, qvm, compiler):
         """Test the application of gates"""
-        dev = plf.QVMDevice(device='3q-qvm', shots=shots)
+        dev = plf.QVMDevice(device="3q-qvm", shots=shots)
 
         try:
             # get the equivalent pennylane operation class
@@ -249,17 +273,17 @@ class TestQVMBasic(BaseTest):
         # the list of wires to apply the operation to
         w = list(range(op.num_wires))
 
-        if op.par_domain == 'A':
+        if op.par_domain == "A":
             # the parameter is an array
-            if gate == 'QubitUnitary':
+            if gate == "QubitUnitary":
                 p = [U]
                 w = [0]
                 state = apply_unitary(U, 3)
-            elif gate == 'BasisState':
+            elif gate == "BasisState":
                 p = [np.array([1, 1, 1])]
                 state = np.array([0, 0, 0, 0, 0, 0, 0, 1])
         else:
-            p = [0.432423, 2, 0.324][:op.num_params]
+            p = [0.432423, 2, 0.324][: op.num_params]
             fn = test_operation_map[gate]
 
             if callable(fn):
@@ -277,60 +301,63 @@ class TestQVMBasic(BaseTest):
         dev._obs_queue = []
         dev.pre_measure()
 
-        res = dev.expval('PauliZ', wires=[0], par=None)
+        res = dev.expval("PauliZ", wires=[0], par=None)
         expected = np.vdot(state, np.kron(np.kron(Z, I), I) @ state)
 
         # verify the device is now in the expected state
         # Note we have increased the tolerance here, since we are only
         # performing 1024 shots.
-        self.assertAllAlmostEqual(res, expected, delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(res, expected, delta=3 / np.sqrt(shots))
 
 
 class TestQVMIntegration(BaseTest):
     """Test the QVM simulator works correctly from the PennyLane frontend."""
-    #pylint: disable=no-self-use
+
+    # pylint: disable=no-self-use
 
     def test_load_qvm_device(self):
         """Test that the QVM device loads correctly"""
-        dev = qml.device('forest.qvm', device='2q-qvm')
+        dev = qml.device("forest.qvm", device="2q-qvm")
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.shots, 1024)
-        self.assertEqual(dev.short_name, 'forest.qvm')
+        self.assertEqual(dev.short_name, "forest.qvm")
 
     def test_load_qvm_device_from_topology(self):
         """Test that the QVM device, from an input topology, loads correctly"""
         topology = nx.complete_graph(2)
-        dev = qml.device('forest.qvm', device=topology)
+        dev = qml.device("forest.qvm", device=topology)
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.shots, 1024)
-        self.assertEqual(dev.short_name, 'forest.qvm')
+        self.assertEqual(dev.short_name, "forest.qvm")
 
     def test_load_virtual_qpu_device(self):
         """Test that the QPU simulators load correctly"""
-        qml.device('forest.qvm', device=np.random.choice(VALID_QPU_LATTICES))
+        qml.device("forest.qvm", device=np.random.choice(VALID_QPU_LATTICES))
 
     def test_incorrect_qc_name(self):
         """Test that exception is raised if name is incorrect"""
-        with pytest.raises(ValueError, match="QVM device string does not indicate the number of qubits"):
-            qml.device('forest.qvm', device='Aspen-1-B')
+        with pytest.raises(
+            ValueError, match="QVM device string does not indicate the number of qubits"
+        ):
+            qml.device("forest.qvm", device="Aspen-1-B")
 
     def test_incorrect_qc_type(self):
         """Test that exception is raised device is not a string or graph"""
         with pytest.raises(ValueError, match="Required argument device must be a string"):
-            qml.device('forest.qvm', device=3)
+            qml.device("forest.qvm", device=3)
 
     def test_qvm_args(self):
         """Test that the QVM plugin requires correct arguments"""
         with pytest.raises(TypeError, match="missing 1 required positional argument"):
-            qml.device('forest.qvm')
+            qml.device("forest.qvm")
 
         with pytest.raises(ValueError, match="Number of shots must be a positive integer"):
-            qml.device('forest.qvm', '2q-qvm', shots=0)
+            qml.device("forest.qvm", "2q-qvm", shots=0)
 
     def test_qubit_unitary(self, shots, qvm, compiler):
         """Test that an arbitrary unitary operation works"""
-        dev1 = qml.device('forest.qvm', device='3q-qvm', shots=shots)
-        dev2 = qml.device('forest.qvm', device='9q-square-qvm', shots=shots)
+        dev1 = qml.device("forest.qvm", device="3q-qvm", shots=shots)
+        dev2 = qml.device("forest.qvm", device="9q-square-qvm", shots=shots)
 
         def circuit():
             """Reference QNode"""
@@ -342,17 +369,21 @@ class TestQVMIntegration(BaseTest):
         circuit1 = qml.QNode(circuit, dev1)
         circuit2 = qml.QNode(circuit, dev2)
 
-        out_state = U2 @ np.array([1, 0, 0, 1])/np.sqrt(2)
+        out_state = U2 @ np.array([1, 0, 0, 1]) / np.sqrt(2)
         obs = np.kron(np.array([[1, 0], [0, -1]]), I)
 
-        self.assertAllAlmostEqual(circuit1(), np.vdot(out_state, obs @ out_state), delta=3/np.sqrt(shots))
-        self.assertAllAlmostEqual(circuit2(), np.vdot(out_state, obs @ out_state), delta=3/np.sqrt(shots))
+        self.assertAllAlmostEqual(
+            circuit1(), np.vdot(out_state, obs @ out_state), delta=3 / np.sqrt(shots)
+        )
+        self.assertAllAlmostEqual(
+            circuit2(), np.vdot(out_state, obs @ out_state), delta=3 / np.sqrt(shots)
+        )
 
-    @pytest.mark.parametrize('device', ['2q-qvm', np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
     def test_one_qubit_wavefunction_circuit(self, device, qvm, compiler):
         """Test that the wavefunction plugin provides correct result for simple circuit"""
         shots = 100000
-        dev = qml.device('forest.qvm', device=device, shots=shots)
+        dev = qml.device("forest.qvm", device=device, shots=shots)
 
         a = 0.543
         b = 0.123
@@ -366,4 +397,4 @@ class TestQVMIntegration(BaseTest):
             qml.Rot(x, y, z, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        self.assertAlmostEqual(circuit(a, b, c), np.cos(a)*np.sin(b), delta=3/np.sqrt(shots))
+        self.assertAlmostEqual(circuit(a, b, c), np.cos(a) * np.sin(b), delta=3 / np.sqrt(shots))

--- a/tests/test_wavefunction.py
+++ b/tests/test_wavefunction.py
@@ -26,7 +26,7 @@ class TestAuxillaryFunctions(BaseTest):
         a, P = spectral_decomposition_qubit(H)
 
         # verify that H = \sum_k a_k P_k
-        self.assertAllAlmostEqual(H, np.einsum('i,ijk->jk', a, P), delta=tol)
+        self.assertAllAlmostEqual(H, np.einsum("i,ijk->jk", a, P), delta=tol)
 
 
 class TestWavefunctionBasic(BaseTest):
@@ -37,16 +37,16 @@ class TestWavefunctionBasic(BaseTest):
         dev = plf.WavefunctionDevice(wires=3)
 
         # expand a two qubit state to the 3 qubit device
-        dev.state = np.array([0, 1, 1, 0])/np.sqrt(2)
+        dev.state = np.array([0, 1, 1, 0]) / np.sqrt(2)
         dev.active_wires = {0, 2}
         dev.expand_state()
-        self.assertAllEqual(dev.state, np.array([0, 1, 0, 0, 1, 0, 0, 0])/np.sqrt(2))
+        self.assertAllEqual(dev.state, np.array([0, 1, 0, 0, 1, 0, 0, 0]) / np.sqrt(2))
 
         # expand a three qubit state to the 3 qubit device
-        dev.state = np.array([0, 1, 1, 0, 0, 1, 1, 0])/2
+        dev.state = np.array([0, 1, 1, 0, 0, 1, 1, 0]) / 2
         dev.active_wires = {0, 1, 2}
         dev.expand_state()
-        self.assertAllEqual(dev.state, np.array([0, 1, 1, 0, 0, 1, 1, 0])/2)
+        self.assertAllEqual(dev.state, np.array([0, 1, 1, 0, 0, 1, 1, 0]) / 2)
 
     def test_expand_one(self, tol):
         """Test that a 1 qubit gate correctly expands to 3 qubits."""
@@ -93,7 +93,9 @@ class TestWavefunctionBasic(BaseTest):
         self.assertAllAlmostEqual(res, expected, delta=tol)
 
         # test exception raised if unphysical subsystems provided
-        with pytest.raises(ValueError, match="Invalid target subsystems provided in 'wires' argument."):
+        with pytest.raises(
+            ValueError, match="Invalid target subsystems provided in 'wires' argument."
+        ):
             dev.expand(U2, [-1, 5])
 
         # test exception raised if incorrect sized matrix provided
@@ -116,12 +118,16 @@ class TestWavefunctionBasic(BaseTest):
 
         # test applied to wire 0,2,3
         res = dev.expand(U_toffoli, [0, 2, 3])
-        expected = np.kron(SWAP, np.kron(I, I)) @ np.kron(I, U_toffoli) @ np.kron(SWAP, np.kron(I, I))
+        expected = (
+            np.kron(SWAP, np.kron(I, I)) @ np.kron(I, U_toffoli) @ np.kron(SWAP, np.kron(I, I))
+        )
         self.assertAllAlmostEqual(res, expected, delta=tol)
 
         # test applied to wire 0,1,3
         res = dev.expand(U_toffoli, [0, 1, 3])
-        expected = np.kron(np.kron(I, I), SWAP) @ np.kron(U_toffoli, I) @ np.kron(np.kron(I, I), SWAP)
+        expected = (
+            np.kron(np.kron(I, I), SWAP) @ np.kron(U_toffoli, I) @ np.kron(np.kron(I, I), SWAP)
+        )
         self.assertAllAlmostEqual(res, expected, delta=tol)
 
         # test applied to wire 3, 1, 2
@@ -135,7 +141,11 @@ class TestWavefunctionBasic(BaseTest):
         res = dev.expand(U_toffoli, [3, 0, 2])
         # change the control qubit on the Toffoli gate
         rows = np.array([0, 4, 1, 5, 2, 6, 3, 7])
-        expected = np.kron(SWAP, np.kron(I, I)) @ np.kron(I, U_toffoli[:, rows][rows]) @ np.kron(SWAP, np.kron(I, I))
+        expected = (
+            np.kron(SWAP, np.kron(I, I))
+            @ np.kron(I, U_toffoli[:, rows][rows])
+            @ np.kron(SWAP, np.kron(I, I))
+        )
         self.assertAllAlmostEqual(res, expected, delta=tol)
 
     @pytest.mark.parametrize("ev", plf.WavefunctionDevice.observables)
@@ -144,7 +154,7 @@ class TestWavefunctionBasic(BaseTest):
         dev = plf.WavefunctionDevice(wires=2)
 
         # start in the following initial state
-        dev.state = np.array([1, 0, 1, 1])/np.sqrt(3)
+        dev.state = np.array([1, 0, 1, 1]) / np.sqrt(3)
         dev.active_wires = {0, 1}
 
         # get the equivalent pennylane operation class
@@ -172,12 +182,12 @@ class TestWavefunctionBasic(BaseTest):
         theta = 0.6543
 
         # test correct variance for <Z> of a rotated state
-        dev.apply('RX', wires=[0], par=[phi])
-        dev.apply('RY', wires=[0], par=[theta])
+        dev.apply("RX", wires=[0], par=[phi])
+        dev.apply("RY", wires=[0], par=[theta])
         dev.pre_measure()
 
-        var = dev.var('PauliZ', [0], [])
-        expected = 0.25*(3-np.cos(2*theta)-2*np.cos(theta)**2*np.cos(2*phi))
+        var = dev.var("PauliZ", [0], [])
+        expected = 0.25 * (3 - np.cos(2 * theta) - 2 * np.cos(theta) ** 2 * np.cos(2 * phi))
 
         self.assertAlmostEqual(var, expected, delta=tol)
 
@@ -190,18 +200,24 @@ class TestWavefunctionBasic(BaseTest):
         theta = 0.6543
 
         # test correct variance for <H> of a rotated state
-        H = np.array([[4, -1+6j], [-1-6j, 2]])
-        dev.apply('RX', wires=[0], par=[phi])
-        dev.apply('RY', wires=[0], par=[theta])
+        H = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
+        dev.apply("RX", wires=[0], par=[phi])
+        dev.apply("RY", wires=[0], par=[theta])
         dev.pre_measure()
 
-        var = dev.var('Hermitian', [0], [H])
-        expected = 0.5*(2*np.sin(2*theta)*np.cos(phi)**2+24*np.sin(phi)\
-                    *np.cos(phi)*(np.sin(theta)-np.cos(theta))+35*np.cos(2*phi)+39)
+        var = dev.var("Hermitian", [0], [H])
+        expected = 0.5 * (
+            2 * np.sin(2 * theta) * np.cos(phi) ** 2
+            + 24 * np.sin(phi) * np.cos(phi) * (np.sin(theta) - np.cos(theta))
+            + 35 * np.cos(2 * phi)
+            + 39
+        )
 
         self.assertAlmostEqual(var, expected, delta=tol)
 
-    @pytest.mark.parametrize("gate", plf.WavefunctionDevice._operation_map) #pylint: disable=protected-access
+    @pytest.mark.parametrize(
+        "gate", plf.WavefunctionDevice._operation_map
+    )  # pylint: disable=protected-access
     def test_apply(self, gate, apply_unitary, tol, qvm, compiler):
         """Test the application of gates to a state"""
         dev = plf.WavefunctionDevice(wires=3)
@@ -216,17 +232,17 @@ class TestWavefunctionBasic(BaseTest):
         # the list of wires to apply the operation to
         w = list(range(op.num_wires))
 
-        if op.par_domain == 'A':
+        if op.par_domain == "A":
             # the parameter is an array
-            if gate == 'QubitUnitary':
+            if gate == "QubitUnitary":
                 p = [U]
                 w = [0]
                 expected_out = apply_unitary(U, 3)
-            elif gate == 'BasisState':
+            elif gate == "BasisState":
                 p = [np.array([1, 1, 1])]
                 expected_out = np.array([0, 0, 0, 0, 0, 0, 0, 1])
         else:
-            p = [0.432423, 2, 0.324][:op.num_params]
+            p = [0.432423, 2, 0.324][: op.num_params]
             fn = test_operation_map[gate]
 
             if callable(fn):
@@ -249,18 +265,19 @@ class TestWavefunctionBasic(BaseTest):
 
 class TestWavefunctionIntegration(BaseTest):
     """Test the wavefunction simulator works correctly from the PennyLane frontend."""
+
     # pylint:disable=no-self-use
 
     def test_load_wavefunction_device(self):
         """Test that the wavefunction device loads correctly"""
-        dev = qml.device('forest.wavefunction', wires=2)
+        dev = qml.device("forest.wavefunction", wires=2)
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.shots, 0)
-        self.assertEqual(dev.short_name, 'forest.wavefunction')
+        self.assertEqual(dev.short_name, "forest.wavefunction")
 
     def test_program_property(self, qvm, compiler):
         """Test that the program property works as expected"""
-        dev = qml.device('forest.wavefunction', wires=2)
+        dev = qml.device("forest.wavefunction", wires=2)
 
         @qml.qnode(dev)
         def circuit():
@@ -274,16 +291,16 @@ class TestWavefunctionIntegration(BaseTest):
         # construct and run the program
         circuit()
         self.assertEqual(len(dev.program), 2)
-        self.assertEqual(str(dev.program), 'H 0\nY 0\n')
+        self.assertEqual(str(dev.program), "H 0\nY 0\n")
 
     def test_wavefunction_args(self):
         """Test that the wavefunction plugin requires correct arguments"""
         with pytest.raises(TypeError, match="missing 1 required positional argument: 'wires'"):
-            qml.device('forest.wavefunction')
+            qml.device("forest.wavefunction")
 
     def test_hermitian_expectation(self, tol, qvm, compiler):
         """Test that an arbitrary Hermitian expectation value works"""
-        dev = qml.device('forest.wavefunction', wires=1)
+        dev = qml.device("forest.wavefunction", wires=1)
 
         @qml.qnode(dev)
         def circuit():
@@ -292,12 +309,12 @@ class TestWavefunctionIntegration(BaseTest):
             qml.PauliY(wires=0)
             return qml.expval(qml.Hermitian(H, 0))
 
-        out_state = 1j*np.array([-1, 1])/np.sqrt(2)
+        out_state = 1j * np.array([-1, 1]) / np.sqrt(2)
         self.assertAllAlmostEqual(circuit(), np.vdot(out_state, H @ out_state), delta=tol)
 
     def test_qubit_unitary(self, tol, qvm, compiler):
         """Test that an arbitrary unitary operation works"""
-        dev = qml.device('forest.wavefunction', wires=3)
+        dev = qml.device("forest.wavefunction", wires=3)
 
         @qml.qnode(dev)
         def circuit():
@@ -307,13 +324,13 @@ class TestWavefunctionIntegration(BaseTest):
             qml.QubitUnitary(U2, wires=[0, 1])
             return qml.expval(qml.PauliZ(0))
 
-        out_state = U2 @ np.array([1, 0, 0, 1])/np.sqrt(2)
+        out_state = U2 @ np.array([1, 0, 0, 1]) / np.sqrt(2)
         obs = np.kron(np.array([[1, 0], [0, -1]]), I)
         self.assertAllAlmostEqual(circuit(), np.vdot(out_state, obs @ out_state), delta=tol)
 
     def test_invalid_qubit_unitary(self):
         """Test that an invalid unitary operation is not allowed"""
-        dev = qml.device('forest.wavefunction', wires=3)
+        dev = qml.device("forest.wavefunction", wires=3)
 
         def circuit(Umat):
             """Test QNode"""
@@ -334,7 +351,7 @@ class TestWavefunctionIntegration(BaseTest):
 
     def test_one_qubit_wavefunction_circuit(self, tol, qvm, compiler):
         """Test that the wavefunction plugin provides correct result for simple circuit"""
-        dev = qml.device('forest.wavefunction', wires=1)
+        dev = qml.device("forest.wavefunction", wires=1)
 
         a = 0.543
         b = 0.123
@@ -348,12 +365,12 @@ class TestWavefunctionIntegration(BaseTest):
             qml.Rot(x, y, z, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        self.assertAlmostEqual(circuit(a, b, c), np.cos(a)*np.sin(b), delta=tol)
+        self.assertAlmostEqual(circuit(a, b, c), np.cos(a) * np.sin(b), delta=tol)
 
     def test_two_qubit_wavefunction_circuit(self, tol, qvm, compiler):
         """Test that the wavefunction plugin provides correct result for simple 2-qubit circuit,
         even when the number of wires > number of qubits."""
-        dev = qml.device('forest.wavefunction', wires=3)
+        dev = qml.device("forest.wavefunction", wires=3)
 
         a = 0.543
         b = 0.123
@@ -371,12 +388,14 @@ class TestWavefunctionIntegration(BaseTest):
             plf.CPHASE(w, 0, wires=[0, 1])
             return qml.expval(qml.PauliY(1))
 
-        self.assertAlmostEqual(circuit(theta, a, b, c), -np.sin(b/2)**2*np.sin(2*theta), delta=tol)
+        self.assertAlmostEqual(
+            circuit(theta, a, b, c), -np.sin(b / 2) ** 2 * np.sin(2 * theta), delta=tol
+        )
 
     def test_nonzero_shots(self, qvm, compiler):
         """Test that the wavefunction plugin provides correct result for high shot number"""
-        shots = 10**2
-        dev = qml.device('forest.wavefunction', wires=1, shots=shots)
+        shots = 10 ** 2
+        dev = qml.device("forest.wavefunction", wires=1, shots=shots)
 
         a = 0.543
         b = 0.123
@@ -394,5 +413,5 @@ class TestWavefunctionIntegration(BaseTest):
         for _ in range(100):
             runs.append(circuit(a, b, c))
 
-        expected_var = np.sqrt(1/shots)
-        self.assertAlmostEqual(np.mean(runs), np.cos(a)*np.sin(b), delta=expected_var)
+        expected_var = np.sqrt(1 / shots)
+        self.assertAlmostEqual(np.mean(runs), np.cos(a) * np.sin(b), delta=expected_var)


### PR DESCRIPTION
This PR adds support for the `pennylane.var()` measurement return type newly added to PennyLane v0.4.

* Adds the device method `var()` to all devices

* Adds corresponding tests, to ensure the variance is correctly calculated.

* Updates the minimum required PennyLane version to 0.4

* Update the documentation to reflect PennyLane v0.4 support