### PR TITLE
Updates the plugin to work with PyQuil 2.13 and PennyLane 0.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ We also encourage bug reports, suggestions for new features and enhancements, an
 Authors
 =======
 
-`Josh Izaac <https://github.com/josh146>`_, `Keri A. McKiernan <https://github.com/kmckiern>`_
+`Josh Izaac <https://github.com/josh146>`_, `Keri A. McKiernan <https://github.com/kmckiern>`_, `M. Sohaib Alam <https://github.com/msohaibalam>`_
 
 
 Support

--- a/README.rst
+++ b/README.rst
@@ -9,9 +9,9 @@ PennyLane Forest Plugin
     :alt: Documentation Status
     :target: http://pennylane-forest.readthedocs.io/en/latest/?badge=latest
 
-Contains the PennyLane Forest plugin. This plugin allows three Rigetti devices to work with PennyLane - the wavefunction simulator, the Quantum Virtual Machine (QVM), and Quantum Processing Units (QPUs).
+Contains the PennyLane Forest plugin. This plugin allows three Rigetti devices to work with PennyLane --- the wavefunction simulator, the Quantum Virtual Machine (QVM), and Quantum Processing Units (QPUs).
 
-`pyQuil <https://pyquil.readthedocs.io>`_ is a Python library for quantum programming using the quantum instruction language (Quil) - resulting quantum programs can be executed using the `Rigetti Forest SDK <https://www.rigetti.com/forest>`_ and the `Rigetti QCS <https://www.rigetti.com/qcs>`_.
+`pyQuil <https://pyquil.readthedocs.io>`_ is a Python library for quantum programming using the quantum instruction language (Quil) --- resulting quantum programs can be executed using the `Rigetti Forest SDK <https://www.rigetti.com/forest>`_ and the `Rigetti QCS <https://www.rigetti.com/qcs>`_.
 
 `PennyLane <https://pennylane.readthedocs.io>`_ is a machine learning library for optimization and automatic differentiation of hybrid quantum-classical computations.
 

--- a/pennylane_forest/_version.py
+++ b/pennylane_forest/_version.py
@@ -2,4 +2,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.4.0-dev"
+__version__ = "0.6.0"

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -179,14 +179,15 @@ class ForestDevice(Device):
             variable ``QUILC_URL``, or in the ``~/.forest_config`` configuration file.
             Default value is ``"http://127.0.0.1:6000"``.
     """
-    pennylane_requires = ">=0.4"
+    pennylane_requires = ">=0.6"
     version = __version__
     author = "Josh Izaac"
 
     _operation_map = pyquil_operation_map
 
-    def __init__(self, wires, shots, **kwargs):
+    def __init__(self, wires, shots=1000, analytic=False,  **kwargs):
         super().__init__(wires, shots)
+        self.analytic = analytic
         self.forest_url = kwargs.get("forest_url", pyquil_config.forest_url)
         self.qvm_url = kwargs.get("qvm_url", pyquil_config.qvm_url)
         self.compiler_url = kwargs.get("compiler_url", pyquil_config.quilc_url)

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -43,8 +43,8 @@ class NumpyWavefunctionDevice(WavefunctionDevice):
 
     observables = {"PauliX", "PauliY", "PauliZ", "Hadamard", "Hermitian", "Identity"}
 
-    def __init__(self, wires, *, shots=0, **kwargs):
-        super(WavefunctionDevice, self).__init__(wires, shots, **kwargs)
+    def __init__(self, wires, *, shots=1000, analytic=True, **kwargs):
+        super(WavefunctionDevice, self).__init__(wires, shots, analytic, **kwargs)
         self.qc = PyQVM(n_qubits=wires, quantum_simulator_type=NumpyWavefunctionSimulator)
         self.state = None
 

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -181,15 +181,8 @@ class QVMDevice(ForestDevice):
     def var(self, observable, wires, par):
         return np.var(self.sample(observable, wires, par))
 
-    def sample(self, observable, wires, par, n=None):
-        if n is None:
-            n = self.shots
-
-        if n == 0:
-            raise ValueError("Calling sample with n = 0 is not possible.")
-
-        if n < 0 or not isinstance(n, int):
-            raise ValueError("The number of samples must be a positive integer.")
+    def sample(self, observable, wires, par):
+        n = self.shots
 
         if observable == "Identity":
             return np.ones([n])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyquil>=2.7
-pennylane>=0.4
+pennylane>=0.6
 networkx

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("pennylane_forest/_version.py") as f:
 
 requirements = [
     "pyquil>=2.7",
-    "pennylane>=0.4"
+    "pennylane>=0.6"
 ]
 
 info = {

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -309,7 +309,7 @@ class TestQVMBasic(BaseTest):
         # performing 1024 shots.
         self.assertAllAlmostEqual(res, expected, delta=3 / np.sqrt(shots))
 
-    def test_sample_values(self, tol):
+    def test_sample_values(self, qvm, tol):
         """Tests if the samples returned by sample have
         the correct values
         """
@@ -319,13 +319,13 @@ class TestQVMBasic(BaseTest):
         dev._obs_queue = [qml.PauliZ(wires=[0], do_queue=False)]
         dev.pre_measure()
 
-        s1 = dev.sample('PauliZ', [0], [], 10)
+        s1 = dev.sample('PauliZ', [0], [])
 
         # s1 should only contain 1 and -1
         self.assertAllAlmostEqual(s1**2, 1, delta=tol)
         self.assertAllAlmostEqual(s1, 1-2*dev.state[0], delta=tol)
 
-    def test_sample_values_hermitian(self, tol):
+    def test_sample_values_hermitian(self, qvm, tol):
         """Tests if the samples of a Hermitian observable returned by sample have
         the correct values
         """
@@ -339,7 +339,7 @@ class TestQVMBasic(BaseTest):
         dev._obs_queue = [qml.Hermitian(A, wires=[0], do_queue=False)]
         dev.pre_measure()
 
-        s1 = dev.sample('Hermitian', [0], [A], shots)
+        s1 = dev.sample('Hermitian', [0], [A])
 
         # s1 should only contain the eigenvalues of
         # the hermitian matrix
@@ -352,7 +352,7 @@ class TestQVMBasic(BaseTest):
         # the analytic variance is 0.25*(sin(theta)-4*cos(theta))^2
         assert np.allclose(np.var(s1), 0.25*(np.sin(theta)-4*np.cos(theta))**2, atol=0.1, rtol=0)
 
-    def test_sample_values_hermitian_multi_qubit(self, tol):
+    def test_sample_values_hermitian_multi_qubit(self, qvm, tol):
         """Tests if the samples of a multi-qubit Hermitian observable returned by sample have
         the correct values
         """
@@ -374,7 +374,7 @@ class TestQVMBasic(BaseTest):
         dev._obs_queue = [qml.Hermitian(A, wires=[0, 1], do_queue=False)]
         dev.pre_measure()
 
-        s1 = dev.sample('Hermitian', [0, 1], [A], shots)
+        s1 = dev.sample('Hermitian', [0, 1], [A])
 
         # s1 should only contain the eigenvalues of
         # the hermitian matrix
@@ -385,34 +385,6 @@ class TestQVMBasic(BaseTest):
         expected = (88*np.sin(theta) + 24*np.sin(2*theta) - 40*np.sin(3*theta)
             + 5*np.cos(theta) - 6*np.cos(2*theta) + 27*np.cos(3*theta) + 6)/32
         assert np.allclose(np.mean(s1), expected, atol=0.1, rtol=0)
-
-    def test_sample_exception_analytic_mode(self):
-        """Tests if the sampling raises an error for sample size n=0
-        """
-        dev = plf.QVMDevice(device="1q-qvm", shots=10)
-        dev.apply('RX', wires=[0], par=[0.4])
-        dev._obs_queue = [qml.PauliZ(wires=0, do_queue=False)]
-        dev.pre_measure()
-
-        with pytest.raises(ValueError, match="Calling sample with n = 0 is not possible"):
-            dev.sample('PauliZ', [0], [], n=0)
-
-    @pytest.mark.parametrize("n", [-12, 12.3])
-    def test_sample_exception_wrong_n(self, n):
-        """Tests if the sampling raises an error for sample size n<0
-        or non-integer n
-        """
-        dev = plf.QVMDevice(device="1q-qvm", shots=10)
-        dev.apply('RX', wires=[0], par=[0.4])
-        dev._obs_queue = [qml.PauliZ(wires=0, do_queue=False)]
-        dev.pre_measure()
-
-        with pytest.raises(ValueError, match="The number of samples must be a positive integer"):
-            dev.sample('PauliZ', [0], [], n=n)
-
-        # self.def.shots = 0, so this should also fail
-        with pytest.raises(ValueError, match="The number of samples must be a positive integer"):
-            dev.sample('PauliZ', [0], [], n=n)
 
 
 class TestQVMIntegration(BaseTest):

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -330,7 +330,7 @@ class TestQVMBasic(BaseTest):
         the correct values
         """
         theta = 0.543
-        shots = 100000
+        shots = 1000_000
         A = np.array([[1, 2j], [-2j, 0]])
 
         dev = plf.QVMDevice(device="1q-qvm", shots=shots)

--- a/tests/test_wavefunction.py
+++ b/tests/test_wavefunction.py
@@ -179,7 +179,7 @@ class TestWavefunctionBasic(BaseTest):
         """Tests if the samples of a Hermitian observable returned by sample have
         the correct values
         """
-        dev = plf.WavefunctionDevice(wires=1, shots=1000)
+        dev = plf.WavefunctionDevice(wires=1, shots=1000_000)
         theta = 0.543
 
         dev.apply('RX', wires=[0], par=[theta])
@@ -204,7 +204,7 @@ class TestWavefunctionBasic(BaseTest):
         """Tests if the samples of a multi-qubit Hermitian observable returned by sample have
         the correct values
         """
-        dev = plf.WavefunctionDevice(wires=2, shots=1000)
+        dev = plf.WavefunctionDevice(wires=2, shots=1000_000)
         theta = 0.543
 
         dev.apply('RX', wires=[0], par=[theta])


### PR DESCRIPTION
**Description of changes**:

* Version bump to 0.6.0, updated requirements and setup.py

* The way measurement statistics works has changed in the latest version of PennyLane. Now, rather than `shots=0` referring to 'analytic' mode, there is a separate `analytic` argument. Further, the `num_shots` argument has been removed from `Device.samples()`.

* Tests that are no redundant due to the above change have been removed.

**Drawbacks**:

Note that there are two outstanding issues related to versions of PyQuil >= 2.11:

* PyQVM is significantly slower compared to PyQuil 2.10

* `QubitUnitary` no longer works with the NumPy Wavefunction Simulator (see https://github.com/rigetti/pyquil/issues/1059).

Once merged, a new release should be made to PyPI.
