### PR TITLE
QPU Parity

### DIFF
--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -102,7 +102,7 @@ class QPUDevice(QVMDevice):
         self.active_reset = active_reset
         self.symmetrize_readout = symmetrize_readout
         self.calibrate_readout = calibrate_readout
-        self.wiring = {q: i for i, q in enumerate(self.qc.qubits())}
+        self.wiring = {i: q for i, q in enumerate(self.qc.qubits())}
 
     def pre_rotations(self, observable, wires):
         """
@@ -127,8 +127,12 @@ class QPUDevice(QVMDevice):
             }
             # expectation values for single-qubit observables
             if observable in ["PauliX", "PauliY", "PauliZ", "Identity", "Hadamard"]:
-                # qubit = self.qc.qubits()[0]
-                prep_prog = Program([instr for instr in self.program if isinstance(instr, Gate)])
+                prep_prog = Program()
+                for instr in self.program.instructions:
+                    if isinstance(instr, Gate):
+                        # assumes single qubit gates
+                        gate, _ = instr.out().split(' ')
+                        prep_prog += Program(str(gate) + ' ' + str(qubit))
                 if self.readout_error is not None:
                     prep_prog.define_noisy_readout(qubit, p00=self.readout_error[0],
                                                           p11=self.readout_error[1])

--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -102,6 +102,7 @@ class QPUDevice(QVMDevice):
         self.active_reset = active_reset
         self.symmetrize_readout = symmetrize_readout
         self.calibrate_readout = calibrate_readout
+        self.wiring = {q: i for i, q in enumerate(self.qc.qubits())}
 
     def pre_rotations(self, observable, wires):
         """
@@ -111,20 +112,22 @@ class QPUDevice(QVMDevice):
         pass
 
     def expval(self, observable, wires, par):
-        # identify Experiment Settings for each of the possible observables
-        d_expt_settings = {
-            "Identity": [ExperimentSetting(TensorProductState(), sI(0))],
-            "PauliX": [ExperimentSetting(TensorProductState(), sX(0))],
-            "PauliY": [ExperimentSetting(TensorProductState(), sY(0))],
-            "PauliZ": [ExperimentSetting(TensorProductState(), sZ(0))],
-            "Hadamard": [ExperimentSetting(TensorProductState(), float(np.sqrt(1/2)) * sX(0)),
-                         ExperimentSetting(TensorProductState(), float(np.sqrt(1/2)) * sZ(0))]
-        }
-        # expectation values for single-qubit observables
+        # Single-qubit observable
         if len(wires) == 1:
-
+            # identify Experiment Settings for each of the possible single-qubit observables
+            wire = wires[0]
+            qubit = self.wiring[wire]
+            d_expt_settings = {
+                "Identity": [ExperimentSetting(TensorProductState(), sI(qubit))],
+                "PauliX": [ExperimentSetting(TensorProductState(), sX(qubit))],
+                "PauliY": [ExperimentSetting(TensorProductState(), sY(qubit))],
+                "PauliZ": [ExperimentSetting(TensorProductState(), sZ(qubit))],
+                "Hadamard": [ExperimentSetting(TensorProductState(), float(np.sqrt(1/2)) * sX(qubit)),
+                             ExperimentSetting(TensorProductState(), float(np.sqrt(1/2)) * sZ(qubit))]
+            }
+            # expectation values for single-qubit observables
             if observable in ["PauliX", "PauliY", "PauliZ", "Identity", "Hadamard"]:
-                qubit = self.qc.qubits()[0]
+                # qubit = self.qc.qubits()[0]
                 prep_prog = Program([instr for instr in self.program if isinstance(instr, Gate)])
                 if self.readout_error is not None:
                     prep_prog.define_noisy_readout(qubit, p00=self.readout_error[0],

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -56,16 +56,10 @@ class TestQPUBasic(BaseTest):
     # pylint: disable=protected-access
 
     def test_no_readout_correction(self):
-        # need to find a device with qubit 0
-        found_good_device = False
-        while not found_good_device:
-            device = np.random.choice(VALID_QPU_LATTICES)
-            dev_qpu = qml.device('forest.qpu', device=device, load_qc=False, readout_error=[0.9, 0.75],
-                                symmetrize_readout=None, calibrate_readout=None)
-            if 0 in dev_qpu.qc.qubits():
-                found_good_device = True
-
-        qubit = 0
+        device = np.random.choice(VALID_QPU_LATTICES)
+        dev_qpu = qml.device('forest.qpu', device=device, load_qc=False, readout_error=[0.9, 0.75],
+                            symmetrize_readout=None, calibrate_readout=None)
+        qubit = 0   # just run program on the first qubit
 
         @qml.qnode(dev_qpu)
         def circuit_Xpl():
@@ -109,16 +103,11 @@ class TestQPUBasic(BaseTest):
         assert np.allclose(results[:3], 0.8, atol=2e-2)
         assert np.allclose(results[3:], -0.5, atol=2e-2)
 
-    def test_no_readout_correction(self):
-        # need to find a device with qubit 0
-        found_good_device = False
-        while not found_good_device:
-            device = np.random.choice(VALID_QPU_LATTICES)
-            dev_qpu = qml.device('forest.qpu', device=device, load_qc=False, readout_error=[0.9, 0.75])
-            if 0 in dev_qpu.qc.qubits():
-                found_good_device = True
-
-        qubit = 0
+    def test_readout_correction(self):
+        device = np.random.choice(VALID_QPU_LATTICES)
+        dev_qpu = qml.device('forest.qpu', device=device, load_qc=False, readout_error=[0.9, 0.75],
+                            symmetrize_readout="exhaustive", calibrate_readout="plus-eig")
+        qubit = 0   # just run program on the first qubit
 
         @qml.qnode(dev_qpu)
         def circuit_Xpl():


### PR DESCRIPTION
Addressing issue #20 and increasing parity between the QVM and QPU abstractions. Circuits run on e.g. wire 0 will now run on the (0-indexed) first qubit on the physical lattice.