### PR TITLE
Fix bug in test_load_qpu_device

### DIFF
--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -22,7 +22,8 @@ class TestQPUIntegration(BaseTest):
 
     def test_load_qpu_device(self):
         """Test that the QPU device loads correctly"""
-        device = [qpu for qpu in VALID_QPU_LATTICES if '2Q' in qpu][0]
+        device = [qpu for qpu in VALID_QPU_LATTICES if '-2Q' in qpu][0]
+        print(device)
         dev = qml.device("forest.qpu", device=device, load_qc=False)
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.shots, 1024)

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -23,7 +23,6 @@ class TestQPUIntegration(BaseTest):
     def test_load_qpu_device(self):
         """Test that the QPU device loads correctly"""
         device = [qpu for qpu in VALID_QPU_LATTICES if '-2Q' in qpu][0]
-        print(device)
         dev = qml.device("forest.qpu", device=device, load_qc=False)
         self.assertEqual(dev.num_wires, 2)
         self.assertEqual(dev.shots, 1024)


### PR DESCRIPTION
We are currently testing an arbitrary 2Q QPU device by using the filter
```python
device = [qpu for qpu in VALID_QPU_LATTICES if '2Q' in qpu][0]
```

However, since there is a now a 12Q device, this is picked up erroneously. This PR fixes the bug by changing the line to
```python
device = [qpu for qpu in VALID_QPU_LATTICES if '-2Q' in qpu][0]
```