### PR TITLE
Fixes #32

### DIFF
--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -184,6 +184,7 @@ class ForestDevice(Device):
     author = "Josh Izaac"
 
     _operation_map = pyquil_operation_map
+    _capabilities = {"model": "qubit"}
 
     def __init__(self, wires, shots=1000, analytic=False,  **kwargs):
         super().__init__(wires, shots)
@@ -225,7 +226,7 @@ class ForestDevice(Device):
 
     def apply(self, operation, wires, par):
         # pylint: disable=attribute-defined-outside-init
-        self.prog += self._operation_map[operation](*par, *wires)
+        self.prog += self._operation_map[operation](*par, *[int(w) for w in wires])
 
         # keep track of the active wires. This is required, as the
         # pyQuil wavefunction simulator creates qubits dynamically.


### PR DESCRIPTION
This PR makes two small changes:

* It ensures that wires are always cast to integers before being used to construct a pyQuil program, solving a recent bug where type validation was added to pyQuil (#32)

* Adds a `Device._capabilities = {"model": "qubit"}` dictionary, so that the device declares to PennyLane that it uses the qubit model. This is now a requirement in PennyLane master, whereas it was optional before.