### PR TITLE
Assuming 1q and 2q gates in QPU.expval

### DIFF
--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -130,9 +130,15 @@ class QPUDevice(QVMDevice):
                 prep_prog = Program()
                 for instr in self.program.instructions:
                     if isinstance(instr, Gate):
-                        # assumes single qubit gates
-                        gate, _ = instr.out().split(' ')
-                        prep_prog += Program(str(gate) + ' ' + str(qubit))
+                        # split gate and wires -- assumes 1q and 2q gates
+                        tup_gate_wires = instr.out().split(' ')
+                        gate = tup_gate_wires[0]
+                        str_instr = str(gate)
+                        # map wires to qubits
+                        for w in tup_gate_wires[1:]:
+                            str_instr += f' {self.wiring[int(w)]}'
+                        prep_prog += Program(str_instr)
+
                 if self.readout_error is not None:
                     prep_prog.define_noisy_readout(qubit, p00=self.readout_error[0],
                                                           p11=self.readout_error[1])

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -150,3 +150,16 @@ class TestQPUBasic(BaseTest):
 
         assert np.allclose(results[:3], 1.0, atol=2e-2)
         assert np.allclose(results[3:], -1.0, atol=2e-2)
+
+    def test_2q_gate(self):
+        device = np.random.choice(VALID_QPU_LATTICES)
+        dev_qpu = qml.device('forest.qpu', device=device, load_qc=False, readout_error=[0.9, 0.75],
+                            symmetrize_readout="exhaustive", calibrate_readout="plus-eig")
+
+        @qml.qnode(dev_qpu)
+        def circuit():
+            qml.RY(np.pi/2, wires=[0])
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0))
+
+        assert np.allclose(circuit(), 0.0, atol=2e-2)


### PR DESCRIPTION
The preparation prog for operator estimation can now handle 1q and 2q gates (but note that it probably won't work with statement involving more than one qubit, e.g. those involving `CONTROLLED` etc).

Fixes #34 .