### PR TITLE
Fixes the plugin to support pyQuil 2.16

### DIFF
--- a/pennylane_forest/converter.py
+++ b/pennylane_forest/converter.py
@@ -324,7 +324,7 @@ class ProgramLoader:
         program (pyquil.quil.Program): The pyquil Program instance that should be loaded
     """
 
-    _matrix_dictionary = pyquil.gate_matrices.QUANTUM_GATES
+    _matrix_dictionary = pyquil.simulation.matrices.QUANTUM_GATES
 
     def __init__(self, program):
         self.program = program

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -226,7 +226,12 @@ class ForestDevice(Device):
 
     def apply(self, operation, wires, par):
         # pylint: disable=attribute-defined-outside-init
-        self.prog += self._operation_map[operation](*par, *[int(w) for w in wires])
+        if hasattr(self, "wiring"):
+            qubits = [int(self.wiring[i]) for i in wires]
+        else:
+            qubits = [int(w) for w in wires]
+
+        self.prog += self._operation_map[operation](*par, *qubits)
 
         # keep track of the active wires. This is required, as the
         # pyQuil wavefunction simulator creates qubits dynamically.

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -24,7 +24,7 @@ import itertools
 import numpy as np
 
 from pyquil.pyqvm import PyQVM
-from pyquil.numpy_simulator import NumpyWavefunctionSimulator
+from pyquil.simulation import NumpyWavefunctionSimulator
 
 from .wavefunction import WavefunctionDevice
 from ._version import __version__

--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -136,7 +136,7 @@ class QPUDevice(QVMDevice):
                         str_instr = str(gate)
                         # map wires to qubits
                         for w in tup_gate_wires[1:]:
-                            str_instr += f' {self.wiring[int(w)]}'
+                            str_instr += f' {int(w)}'
                         prep_prog += Program(str_instr)
 
                 if self.readout_error is not None:

--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -33,7 +33,7 @@ from pyquil.api._quantum_computer import _get_qvm_with_topology
 from pyquil.gates import MEASURE, RESET
 from pyquil.quil import Pragma, Program
 from pyquil.paulis import sI, sX, sY, sZ
-from pyquil.operator_estimation import ExperimentSetting, TensorProductState, TomographyExperiment, measure_observables, group_experiments
+from pyquil.operator_estimation import ExperimentSetting, TensorProductState, Experiment, measure_observables, group_experiments
 from pyquil.quilbase import Gate
 
 
@@ -142,7 +142,7 @@ class QPUDevice(QVMDevice):
                 if self.readout_error is not None:
                     prep_prog.define_noisy_readout(qubit, p00=self.readout_error[0],
                                                           p11=self.readout_error[1])
-                tomo_expt = TomographyExperiment(settings=d_expt_settings[observable], program=prep_prog)
+                tomo_expt = Experiment(settings=d_expt_settings[observable], program=prep_prog)
                 grouped_tomo_expt = group_experiments(tomo_expt)
                 meas_obs = list(measure_observables(self.qc, grouped_tomo_expt,
                                                     active_reset=self.active_reset,

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -158,7 +158,7 @@ class QVMDevice(ForestDevice):
                 # Perform a change of basis before measuring by applying U^ to the circuit
                 self.apply("QubitUnitary", wires, [U.conj().T])
 
-        prag = Program()
+        prag = Program(Pragma("INITIAL_REWIRING", ['"PARTIAL"']))
 
         if self.active_reset:
             prag += RESET()

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -110,6 +110,7 @@ class QVMDevice(ForestDevice):
         elif isinstance(device, str):
             self.qc = get_qc(device, as_qvm=True, noisy=noisy, connection=self.connection)
 
+        self.wiring = {i: q for i, q in enumerate(self.qc.qubits())}
         self.active_reset = False
 
     def pre_rotations(self, observable, wires):
@@ -127,7 +128,6 @@ class QVMDevice(ForestDevice):
         elif observable == "Hadamard":
             # H = Ry(-pi/4)^.Z.Ry(-pi/4)
             self.apply("RY", wires, [-np.pi / 4])
-
 
     def pre_measure(self):
         """Run the QVM"""
@@ -188,6 +188,7 @@ class QVMDevice(ForestDevice):
         return np.var(self.sample(observable, wires, par))
 
     def sample(self, observable, wires, par):
+        wires = [self.wiring[i] for i in wires]
         n = self.shots
 
         if observable == "Identity":

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -112,6 +112,7 @@ class QVMDevice(ForestDevice):
 
         self.wiring = {i: q for i, q in enumerate(self.qc.qubits())}
         self.active_reset = False
+        self.compiled = None
 
     def pre_rotations(self, observable, wires):
         """Apply pre-rotations in the case of observales other than 'Hermitian'"""
@@ -174,8 +175,8 @@ class QVMDevice(ForestDevice):
         if "pyqvm" in self.qc.name:
             bitstring_array = self.qc.run(self.prog)
         else:
-            executable = self.qc.compile(self.prog)
-            bitstring_array = self.qc.run(executable=executable)
+            self.compiled = self.qc.compile(self.prog)
+            bitstring_array = self.qc.run(executable=self.compiled)
 
         self.state = {}
         for i, q in enumerate(qubits):

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -158,7 +158,7 @@ class QVMDevice(ForestDevice):
                 # Perform a change of basis before measuring by applying U^ to the circuit
                 self.apply("QubitUnitary", wires, [U.conj().T])
 
-        prag = Program(Pragma("INITIAL_REWIRING", ['"PARTIAL"']))
+        prag = Program()
 
         if self.active_reset:
             prag += RESET()

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -164,7 +164,7 @@ class QVMDevice(ForestDevice):
 
         self.prog = prag + self.prog
 
-        qubits = list(self.prog.get_qubits())
+        qubits = sorted(self.prog.get_qubits())
         ro = self.prog.declare("ro", "BIT", len(qubits))
         for i, q in enumerate(qubits):
             self.prog.inst(MEASURE(q, ro[i]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyquil>=2.7
+pyquil>=2.16
 pennylane>=0.6
 networkx

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("pennylane_forest/_version.py") as f:
 
 
 requirements = [
-    "pyquil>=2.7",
+    "pyquil>=2.16",
     "pennylane>=0.6"
 ]
 


### PR DESCRIPTION
This PR updates the PennyLane-Forest plugin to support breaking API changes in pyQuil 2.16. In particular:

* The import `pyquil.gate_matrices.QUANTUM_GATES` no longer works, and has been changed to `_matrix_dictionary = pyquil.simulation.matrices.QUANTUM_GATES`.

* `pyquil.numpy_simulator` has been changed to `pyquil.NumpyWavefunctionSimulator`

* `TomographyExperiment` has been changed to `Experiment`.

There are still quite a few deprecation notices, specifically related to tomography:

* FutureWarning: `n_shots` has been deprecated; if you want to set the number of shots for this run of measure_observables please provide the number to `Program.wrap_in_numshots_loop()` for the Quil program that you provide when creating your `TomographyExperiment` object. It looks like your `TomographyExperiment` object has `shots = 1`, so for now we will change that to 10000, which was the previous default value.

* FutureWarning: `active_reset` has been deprecated; if you want to enable active qubit reset please provide a Quil program that has a `RESET` instruction in it when creating your `TomographyExperiment` object. For now, this value will override that in the `TomographyExperiment`, but eventually this keyword argument will be removed.

* FutureWarning: `symmetrize_readout` has been deprecated; please provide the symmetrization level when creating your `TomographyExperiment` object. For now, this value will override that in the `TomographyExperiment`, but eventually this keyword argument will be removed.

@msohaibalam, I'm a bit unsure the best approach to fix these three (I assume the only high priority one is `n_shots`?). Furthermore, is `active_reset` deprecated only for tomography, or for generic QPU runs as well? We do not get a deprecation notice there.

Finally, there is an additional warning I have not noticed before:

```
UserWarning: SIMPLE-WARNING: Chip specification contained fidelity 1.0d0 > 0.99999d0. Truncating to 0.99999d0
```
