### PR TITLE
Bump version number and update requirements

### DIFF
--- a/pennylane_forest/_version.py
+++ b/pennylane_forest/_version.py
@@ -2,4 +2,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.6.0"
+__version__ = "0.8.0"

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -178,9 +178,9 @@ class ForestDevice(QubitDevice):
             variable ``QUILC_URL``, or in the ``~/.forest_config`` configuration file.
             Default value is ``"http://127.0.0.1:6000"``.
     """
-    pennylane_requires = ">=0.6"
+    pennylane_requires = ">=0.8"
     version = __version__
-    author = "Josh Izaac"
+    author = "Rigetti Computing Inc."
 
     _operation_map = pyquil_operation_map
     _capabilities = {"model": "qubit", "tensor_observables": True}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16
-git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
+pennylane>=0.8
 networkx
 flaky

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("pennylane_forest/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
 
-requirements = ["pyquil>=2.16", "pennylane>=0.6"]
+requirements = ["pyquil>=2.16", "pennylane>=0.8"]
 
 info = {
     "name": "PennyLane-Forest",


### PR DESCRIPTION
* Updates the version number to v0.8, to bring it inline with the latest PennyLane release

* Updates the setup.py and requirements.txt, to specify that the plugin now only works with PennyLane v0.8 and above.