### PR TITLE
Correcting tests

### DIFF
--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -359,3 +359,28 @@ class ForestDevice(QubitDevice):
 
         return np.reshape(state_multi_index, 2 ** self.num_wires)
 
+    def analytic_probability(self, wires=None):
+        """Return the (marginal) probability of each computational basis
+        state from the last run of the device.
+
+        If no wires are specified, then all the basis states representable by
+        the device are considered and no marginalization takes place.
+
+        .. warning:: This method will have to be redefined for hardware devices, since it uses
+            the ``device._state`` attribute. This attribute might not be available for such devices.
+
+        Args:
+            wires (Sequence[int]): Sequence of wires to return
+                marginal probabilities for. Wires not provided
+                are traced out of the system.
+
+        Returns:
+            List[float]: list of the probabilities
+        """
+        if self._state is None:
+            return None
+
+        wires = wires or range(self.num_wires)
+        wires = self.remap_wires(wires)
+        prob = self.marginal_prob(np.abs(self._state) ** 2, wires)
+        return prob

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -359,28 +359,3 @@ class ForestDevice(QubitDevice):
 
         return np.reshape(state_multi_index, 2 ** self.num_wires)
 
-    def probability(self, wires=None):
-        """Return the (marginal) probability of each computational basis
-        state from the last run of the device.
-
-        If no wires are specified, then all the basis states representable by
-        the device are considered and no marginalization takes place.
-
-        .. warning:: This method will have to be redefined for hardware devices, since it uses
-            the ``device._state`` attribute. This attribute might not be available for such devices.
-
-        Args:
-            wires (Sequence[int]): Sequence of wires to return
-                marginal probabilities for. Wires not provided
-                are traced out of the system.
-
-        Returns:
-            List[float]: list of the probabilities
-        """
-        if self._state is None:
-            return None
-
-        wires = wires or range(self.num_wires)
-        wires = self.remap_wires(wires)
-        prob = self.marginal_prob(np.abs(self._state) ** 2, wires)
-        return prob

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -60,28 +60,3 @@ class NumpyWavefunctionDevice(ForestDevice):
         # pennylane_forest/wavefunction.py
         self._state = self.qc.execute(self.prog).wf_simulator.wf.flatten()
 
-    def analytic_probability(self, wires=None):
-        """Return the (marginal) probability of each computational basis
-        state from the last run of the device.
-
-        If no wires are specified, then all the basis states representable by
-        the device are considered and no marginalization takes place.
-
-        .. warning:: This method will have to be redefined for hardware devices, since it uses
-            the ``device._state`` attribute. This attribute might not be available for such devices.
-
-        Args:
-            wires (Sequence[int]): Sequence of wires to return
-                marginal probabilities for. Wires not provided
-                are traced out of the system.
-
-        Returns:
-            List[float]: list of the probabilities
-        """
-        if self._state is None:
-            return None
-
-        wires = wires or range(self.num_wires)
-        wires = self.remap_wires(wires)
-        prob = self.marginal_prob(np.abs(self._state) ** 2, wires)
-        return prob

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -59,4 +59,3 @@ class NumpyWavefunctionDevice(ForestDevice):
         # might need to get udpated to be similar to the pre_measure function of
         # pennylane_forest/wavefunction.py
         self._state = self.qc.execute(self.prog).wf_simulator.wf.flatten()
-

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -59,3 +59,29 @@ class NumpyWavefunctionDevice(ForestDevice):
         # might need to get udpated to be similar to the pre_measure function of
         # pennylane_forest/wavefunction.py
         self._state = self.qc.execute(self.prog).wf_simulator.wf.flatten()
+
+    def analytic_probability(self, wires=None):
+        """Return the (marginal) probability of each computational basis
+        state from the last run of the device.
+
+        If no wires are specified, then all the basis states representable by
+        the device are considered and no marginalization takes place.
+
+        .. warning:: This method will have to be redefined for hardware devices, since it uses
+            the ``device._state`` attribute. This attribute might not be available for such devices.
+
+        Args:
+            wires (Sequence[int]): Sequence of wires to return
+                marginal probabilities for. Wires not provided
+                are traced out of the system.
+
+        Returns:
+            List[float]: list of the probabilities
+        """
+        if self._state is None:
+            return None
+
+        wires = wires or range(self.num_wires)
+        wires = self.remap_wires(wires)
+        prob = self.marginal_prob(np.abs(self._state) ** 2, wires)
+        return prob

--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -82,7 +82,7 @@ class QPUDevice(QVMDevice):
         self,
         device,
         *,
-        shots=1024,
+        shots=1000,
         active_reset=True,
         load_qc=True,
         readout_error=None,

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -73,7 +73,7 @@ class QVMDevice(ForestDevice):
     short_name = "forest.qvm"
     observables = {"PauliX", "PauliY", "PauliZ", "Identity", "Hadamard", "Hermitian"}
 
-    def __init__(self, device, *, shots=1024, noisy=False, **kwargs):
+    def __init__(self, device, *, shots=1000, noisy=False, **kwargs):
 
         if shots <= 0:
             raise ValueError("Number of shots must be a positive integer.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16
-pennylane>=0.8
+git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
 networkx
 flaky

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -22,6 +22,11 @@ VALID_QPU_LATTICES = [
     qc for qc in pyquil.list_quantum_computers() if "qvm" not in qc and re.match(pattern, qc)
 ]
 
+pattern_four_qubit = "Aspen-.-4Q-."
+VALID_FOUR_QUBIT_LATTICES = [
+    qc for qc in pyquil.list_quantum_computers() if "qvm" not in qc and re.match(pattern_four_qubit, qc)
+]
+
 
 class TestQPUIntegration(BaseTest):
     """Test the wavefunction simulator works correctly from the PennyLane frontend."""
@@ -33,7 +38,7 @@ class TestQPUIntegration(BaseTest):
         device = [qpu for qpu in VALID_QPU_LATTICES if "-2Q" in qpu][0]
         dev = qml.device("forest.qpu", device=device, load_qc=False)
         self.assertEqual(dev.num_wires, 2)
-        self.assertEqual(dev.shots, 1024)
+        self.assertEqual(dev.shots, 1000)
         self.assertEqual(dev.short_name, "forest.qpu")
 
     def test_load_virtual_qpu_device(self):
@@ -67,17 +72,18 @@ class TestQPUIntegration(BaseTest):
 
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
+        device = np.random.choice(VALID_FOUR_QUBIT_LATTICES)
         p = np.pi / 8
         dev = qml.device(
             "forest.qpu",
-            device="Aspen-4-4Q-E",
+            device=device,
             shots=10000,
             load_qc=False,
             parametric_compilation=True,
         )
         dev_1 = qml.device(
             "forest.qpu",
-            device="Aspen-4-4Q-E",
+            device=device,
             shots=10000,
             load_qc=False,
             parametric_compilation=True,
@@ -113,17 +119,18 @@ class TestQPUIntegration(BaseTest):
 
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
+        device = np.random.choice(VALID_FOUR_QUBIT_LATTICES)
         p = np.pi / 7
         dev = qml.device(
             "forest.qpu",
-            device="Aspen-4-4Q-E",
+            device=device,
             shots=1000,
             load_qc=False,
             parametric_compilation=False,
         )
         dev_1 = qml.device(
             "forest.qpu",
-            device="Aspen-4-4Q-E",
+            device=device,
             shots=1000,
             load_qc=False,
             parametric_compilation=False,
@@ -161,7 +168,7 @@ class TestQPUBasic(BaseTest):
         with pytest.warns(Warning, match="Operator estimation is being turned off."):
             dev = qml.device(
                 "forest.qpu",
-                device="Aspen-4-4Q-E",
+                device=device,
                 shots=1000,
                 load_qc=False,
                 parametric_compilation=True,

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -623,7 +623,8 @@ class TestParametricCompilation(BaseTest):
     ):
         """Tests that a program containing numeric and symbolic variables as well is only compiled once."""
 
-        Variable.free_param_values = {}
+        Variable.positional_arg_values = {}
+
         dev = qml.device("forest.qvm", device="2q-qvm", timeout=100)
 
         dev._circuit_hash = None
@@ -634,8 +635,8 @@ class TestParametricCompilation(BaseTest):
 
         call_history = []
         for run_idx in range(number_of_runs):
-            Variable.free_param_values[1] = 0.232 * run_idx
-            Variable.free_param_values[2] = 0.8764 * run_idx
+            Variable.positional_arg_values[1] = 0.232 * run_idx
+            Variable.positional_arg_values[2] = 0.8764 * run_idx
             circuit_graph = CircuitGraph(queue, observable_queue)
 
             dev.apply(circuit_graph.operations, rotations=circuit_graph.diagonalizing_gates)
@@ -695,7 +696,7 @@ class TestQVMIntegration(BaseTest):
         """Test that the QVM device loads correctly"""
         dev = qml.device("forest.qvm", device="2q-qvm")
         self.assertEqual(dev.num_wires, 2)
-        self.assertEqual(dev.shots, 1024)
+        self.assertEqual(dev.shots, 1000)
         self.assertEqual(dev.short_name, "forest.qvm")
 
     def test_load_qvm_device_from_topology(self, qvm):
@@ -703,7 +704,7 @@ class TestQVMIntegration(BaseTest):
         topology = nx.complete_graph(2)
         dev = qml.device("forest.qvm", device=topology)
         self.assertEqual(dev.num_wires, 2)
-        self.assertEqual(dev.shots, 1024)
+        self.assertEqual(dev.shots, 1000)
         self.assertEqual(dev.short_name, "forest.qvm")
 
     def test_load_virtual_qpu_device(self, qvm):


### PR DESCRIPTION
**Context:**
A number of tests fail while running the test suite due to the following reasons:
* The `"Aspen-4-4Q-E"` lattice, that was specifically used by certain tests, is no longer a valid `QuantumComputer` lattice;
* The default number of shots has been set to `1000` for `QubitDevice` in PL core;
* The `Variable.free_param_values` has been renamed in PL core.
 
**Description of the Change:**
The following parts of the test suite were updated:
* Changed to picking a valid four qubit lattice at runtime instead of hardcoding it in QVM tests;
* Updated the checks for the number of shots;
* Updated the name of the Variable class attribute for argument values coming from PL core.

**Benefits:**
The test suite runs well again.

**Possible drawbacks:**
The name of the Variable class attribute was used and this might potentially break again, should it be subject to another change in PL core.
