### PR TITLE
Update from lattice-based to device-based naming

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ You can instantiate these devices for PennyLane as follows:
     dev_simulator = qml.device('forest.wavefunction', wires=2)
     dev_pyqvm = qml.device('forest.qvm', device='2q-pyqvm', shots=1000)
     dev_qvm = qml.device('forest.qvm', device='2q-qvm', shots=1000)
-    dev_qpu = qml.device('forest.qpu', device='Aspen-0-12Q-A', shots=1000)
+    dev_qpu = qml.device('forest.qpu', device='Aspen-8', shots=1000)
 
 These devices can then be used just like other devices for the definition and evaluation of QNodes within PennyLane. For more details, see the `plugin usage guide <https://pennylane-forest.readthedocs.io/en/latest/usage.html>`_ and refer to the PennyLane documentation.
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -27,7 +27,7 @@ You can instantiate these devices in PennyLane as follows:
 >>> dev_simulator = qml.device('forest.wavefunction', wires=2)
 >>> dev_pyqvm = qml.device('forest.qvm', device='2q-pyqvm', shots=1000)
 >>> dev_qvm = qml.device('forest.qvm', device='2q-qvm', shots=1000)
->>> dev_qpu = qml.device('forest.qpu', device='Aspen-0-12Q-A', shots=1000)
+>>> dev_qpu = qml.device('forest.qpu', device='Aspen-8', shots=1000)
 
 
 
@@ -166,13 +166,13 @@ The ``forest.qvm`` device provides an interface between PennyLane and the Forest
 
 Note that, unlike ``forest.wavefunction``, you do not pass the number of wires - this is inferred automatically from the requested quantum computer topology.
 
->>> dev = qml.device('forest.qvm', device='Aspen-1-16Q-A')
+>>> dev = qml.device('forest.qvm', device='Aspen-8')
 >>> dev.num_wires
 16
 
 In addition, you may also request a QVM with noise models to better simulate a physical QPU; this is done by passing the keyword argument ``noisy=True``:
 
->>> dev = qml.device('forest.qvm', device='Aspen-1-16Q-A', noisy=True)
+>>> dev = qml.device('forest.qvm', device='Aspen-8', noisy=True)
 
 Note that only the `default noise models <http://docs.rigetti.com/en/stable/noise.html>`_ provided by pyQuil are currently supported.
 
@@ -190,11 +190,11 @@ When initializing the ``forest.qvm`` device, the following required keyword argu
     The name or topology of the quantum computer to initialize.
 
     * ``Nq-qvm``: for a fully connected/unrestricted N-qubit QVM
-    * ``9q-qvm-square``: a :math:`9\times 9` lattice.
-    * ``Nq-pyqvm`` or ``9q-pyqvm-square``, for the same as the above but run
+    * ``9q-square-qvm``: a :math:`9\times 9` lattice.
+    * ``Nq-pyqvm`` or ``9q-square-pyqvm``, for the same as the above but run
        via the built-in pyQuil pyQVM device.
     * Any other supported Rigetti device architecture, for
-      example a QPU lattice such as ``'Aspen-1-16Q-A'``.
+      example a QPU lattice such as ``'Aspen-8'``.
     * Graph topology (as a ``networkx.Graph`` object) representing the device architecture.
 
 

--- a/examples/Readout Error Mitigation.ipynb
+++ b/examples/Readout Error Mitigation.ipynb
@@ -35,7 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device_name = 'Aspen-4-4Q-A'"
+    "device_name = 'Aspen-8'"
    ]
   },
   {

--- a/examples/q1-rotation-aspen-qpu-momentum-optimizer.ipynb
+++ b/examples/q1-rotation-aspen-qpu-momentum-optimizer.ipynb
@@ -127,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### create forest QPU device, using the Aspen-1-15Q-A lattice"
+    "### create forest QPU device, using Aspen-8"
    ]
   },
   {
@@ -136,10 +136,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# note that, for this example, we can book any QPU lattice, not necessarily just Aspen-1-15Q-A\n",
+    "# note that, for this example, we can book any available device, not necessarily just Aspen-8\n",
     "\n",
     "dev = qml.device('forest.qpu', \n",
-    "                 device='Aspen-1-15Q-A', \n",
+    "                 device='Aspen-8', \n",
     "                 shots=100,\n",
     "                 active_reset=True)"
    ]

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -166,17 +166,6 @@ class ForestDevice(QubitDevice):
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables.
             For simulator devices, 0 means the exact EV is returned.
-
-    Keyword args:
-        forest_url (str): the Forest URL server. Can also be set by
-            the environment variable ``FOREST_URL``, or in the ``~/.qcs_config``
-            configuration file. Default value is ``"https://forest-server.qcs.rigetti.com"``.
-        qvm_url (str): the QVM server URL. Can also be set by the environment
-            variable ``QVM_URL``, or in the ``~/.forest_config`` configuration file.
-            Default value is ``"http://127.0.0.1:5000"``.
-        quilc_url (str): the compiler server URL. Can also be set by the environment
-            variable ``QUILC_URL``, or in the ``~/.forest_config`` configuration file.
-            Default value is ``"http://127.0.0.1:6000"``.
     """
     pennylane_requires = ">=0.9"
     version = __version__

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -188,35 +188,21 @@ class ForestDevice(QubitDevice):
     def __init__(self, wires, shots=1000, analytic=False, **kwargs):
         super().__init__(wires, shots, analytic=analytic)
         self.analytic = analytic
-        self.forest_url = kwargs.get("forest_url", pyquil_config.forest_url)
-        self.qvm_url = kwargs.get("qvm_url", pyquil_config.qvm_url)
-        self.compiler_url = kwargs.get("compiler_url", pyquil_config.quilc_url)
+        self.reset()
 
-        self.connection = ForestConnection(
-            sync_endpoint=self.qvm_url,
-            compiler_endpoint=self.compiler_url,
-            forest_cloud_endpoint=self.forest_url,
+    @staticmethod
+    def _get_connection(**kwargs):
+        forest_url = kwargs.get("forest_url", pyquil_config.forest_url)
+        qvm_url = kwargs.get("qvm_url", pyquil_config.qvm_url)
+        compiler_url = kwargs.get("compiler_url", pyquil_config.quilc_url)
+
+        connection = ForestConnection(
+            sync_endpoint=qvm_url,
+            compiler_endpoint=compiler_url,
+            forest_cloud_endpoint=forest_url,
         )
 
-        # The following environment variables are deprecated I think
-
-        # api_key (str): the Forest API key. Can also be set by the environment
-        #     variable ``FOREST_API_KEY``, or in the ``~/.qcs_config`` configuration file.
-        # user_id (str): the Forest user ID. Can also be set by the environment
-        #     variable ``FOREST_USER_ID``, or in the ``~/.qcs_config`` configuration file.
-        # qpu_url (str): the QPU server URL. Can also be set by the environment
-        #     variable ``QPU_URL``, or in the ``~/.forest_config`` configuration file.
-
-        # if 'api_key' in kwargs:
-        #     os.environ['FOREST_API_KEY'] = kwargs['api_key']
-
-        # if 'user_id' in kwargs:
-        #     os.environ['FOREST_USER_ID'] = kwargs['user_id']
-
-        # if 'qpu_url' in kwargs:
-        #     os.environ['QPU_URL'] = kwargs['qpu_url']
-
-        self.reset()
+        return connection
 
     @property
     def program(self):

--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -138,6 +138,8 @@ class QPUDevice(QVMDevice):
         if shots <= 0:
             raise ValueError("Number of shots must be a positive integer.")
 
+        self.connection = super()._get_connection(**kwargs)
+
         if load_qc:
             self.qc = get_qc(device, as_qvm=False, connection=self.connection)
             if timeout is not None:

--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -138,11 +138,6 @@ class QPUDevice(QVMDevice):
         if shots <= 0:
             raise ValueError("Number of shots must be a positive integer.")
 
-        aspen_match = re.match(r"Aspen-\d+-([\d]+)Q", device)
-        num_wires = int(aspen_match.groups()[0])
-
-        super(QVMDevice, self).__init__(num_wires, shots, **kwargs)
-
         if load_qc:
             self.qc = get_qc(device, as_qvm=False, connection=self.connection)
             if timeout is not None:
@@ -151,6 +146,10 @@ class QPUDevice(QVMDevice):
             self.qc = get_qc(device, as_qvm=True, connection=self.connection)
             if timeout is not None:
                 self.qc.compiler.client.timeout = timeout
+
+        num_wires = len(self.qc.qubits())
+
+        super(QVMDevice, self).__init__(num_wires, shots, **kwargs)
 
         self.active_reset = active_reset
         self.symmetrize_readout = symmetrize_readout

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -45,8 +45,8 @@ class QVMDevice(ForestDevice):
         device (Union[str, nx.Graph]): the name or topology of the device to initialise.
 
             * ``Nq-qvm``: for a fully connected/unrestricted N-qubit QVM
-            * ``9q-qvm-square``: a :math:`9\times 9` lattice.
-            * ``Nq-pyqvm`` or ``9q-pyqvm-square``, for the same as the above but run
+            * ``9q-square-qvm``: a :math:`9\times 9` lattice.
+            * ``Nq-pyqvm`` or ``9q-square-pyqvm``, for the same as the above but run
               via the built-in pyQuil pyQVM device.
             * Any other supported Rigetti device architecture.
             * Graph topology representing the device architecture.
@@ -112,7 +112,7 @@ class QVMDevice(ForestDevice):
             num_wires = device.number_of_nodes()
         elif isinstance(device, str):
             # the device string must match a valid QVM device, i.e.
-            # N-qvm, or 9q-square-qvm, or Aspen-1-16Q-A
+            # N-qvm, or 9q-square-qvm, or Aspen-8
             wire_match = re.search(r"(\d+)(q|Q)", device)
 
             if wire_match is None:

--- a/pennylane_forest/qvm.py
+++ b/pennylane_forest/qvm.py
@@ -106,6 +106,8 @@ class QVMDevice(ForestDevice):
         if analytic:
             raise ValueError("QVM device cannot be run in analytic=True mode.")
 
+        self.connection = super()._get_connection(**kwargs)
+
         # get the qc
         if isinstance(device, nx.Graph):
             self.qc = _get_qvm_with_topology(

--- a/pennylane_forest/wavefunction.py
+++ b/pennylane_forest/wavefunction.py
@@ -73,6 +73,7 @@ class WavefunctionDevice(ForestDevice):
 
     def __init__(self, wires, *, shots=1000, analytic=True, **kwargs):
         super().__init__(wires, shots, analytic, **kwargs)
+        self.connection = super()._get_connection(**kwargs)
         self.qc = WavefunctionSimulator(connection=self.connection)
         self._state = None
 

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -17,10 +17,7 @@ from flaky import flaky
 
 log = logging.getLogger(__name__)
 
-pattern = "Aspen-."
-VALID_QPU_LATTICES = [
-    qc for qc in pyquil.list_quantum_computers() if "qvm" not in qc and re.match(pattern, qc)
-]
+TEST_QPU_LATTICES = ["4q-qvm"]
 
 
 class TestQPUIntegration(BaseTest):
@@ -30,9 +27,9 @@ class TestQPUIntegration(BaseTest):
 
     def test_load_qpu_device(self):
         """Test that the QPU device loads correctly"""
-        device = VALID_QPU_LATTICES[0]
+        device = TEST_QPU_LATTICES[0]
         dev = qml.device("forest.qpu", device=device, load_qc=False)
-        qc = pyquil.get_qc(device + "-qvm")
+        qc = pyquil.get_qc(device)
         num_wires = len(qc.qubits())
         self.assertEqual(dev.num_wires, num_wires)
         self.assertEqual(dev.shots, 1000)
@@ -40,12 +37,12 @@ class TestQPUIntegration(BaseTest):
 
     def test_load_virtual_qpu_device(self):
         """Test that the QPU simulators load correctly"""
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         qml.device("forest.qpu", device=device, load_qc=False)
 
     def test_qpu_args(self):
         """Test that the QPU plugin requires correct arguments"""
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
 
         with pytest.raises(ValueError, match="QPU device does not support a wires parameter"):
             qml.device("forest.qpu", device=device, wires=2)
@@ -69,7 +66,7 @@ class TestQPUIntegration(BaseTest):
 
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         p = np.pi / 8
         dev = qml.device(
             "forest.qpu",
@@ -116,7 +113,7 @@ class TestQPUIntegration(BaseTest):
 
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         p = np.pi / 7
         dev = qml.device(
             "forest.qpu",
@@ -161,7 +158,7 @@ class TestQPUBasic(BaseTest):
 
     def test_warnings_raised_parametric_compilation_and_operator_estimation(self):
         """Test that a warning is raised if parameter compilation and operator estimation are both turned on."""
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         with pytest.warns(Warning, match="Operator estimation is being turned off."):
             dev = qml.device(
                 "forest.qpu",
@@ -173,7 +170,7 @@ class TestQPUBasic(BaseTest):
 
     def test_no_readout_correction(self):
         """Test the QPU plugin with no readout correction"""
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev_qpu = qml.device(
             "forest.qpu",
             device=device,
@@ -235,7 +232,7 @@ class TestQPUBasic(BaseTest):
 
     def test_readout_correction(self):
         """Test the QPU plugin with readout correction"""
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev_qpu = qml.device(
             "forest.qpu",
             device=device,
@@ -298,7 +295,7 @@ class TestQPUBasic(BaseTest):
     @flaky(max_runs=5, min_passes=3)
     def test_multi_qub_no_readout_errors(self):
         """Test the QPU plugin with no readout errors or correction"""
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev_qpu = qml.device(
             "forest.qpu",
             device=device,
@@ -324,7 +321,7 @@ class TestQPUBasic(BaseTest):
     @flaky(max_runs=5, min_passes=3)
     def test_multi_qub_readout_errors(self):
         """Test the QPU plugin with readout errors"""
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev_qpu = qml.device(
             "forest.qpu",
             device=device,
@@ -349,7 +346,7 @@ class TestQPUBasic(BaseTest):
     @flaky(max_runs=5, min_passes=3)
     def test_multi_qub_readout_correction(self):
         """Test the QPU plugin with readout errors and correction"""
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev_qpu = qml.device(
             "forest.qpu",
             device=device,
@@ -378,7 +375,7 @@ class TestQPUBasic(BaseTest):
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
 
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev_qpu = qml.device(
             "forest.qpu",
             device=device,
@@ -403,7 +400,7 @@ class TestQPUBasic(BaseTest):
 
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev_qpu = qml.device(
             "forest.qpu",
             device=device,
@@ -429,7 +426,7 @@ class TestQPUBasic(BaseTest):
 
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev_qpu = qml.device(
             "forest.qpu",
             device=device,
@@ -461,7 +458,7 @@ class TestQPUBasic(BaseTest):
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
 
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev_qpu = qml.device(
             "forest.qpu",
             device=device,
@@ -499,7 +496,7 @@ class TestQPUBasic(BaseTest):
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
 
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev_qpu = qml.device(
             "forest.qpu",
             device=device,
@@ -533,14 +530,14 @@ class TestQPUBasic(BaseTest):
     def test_timeout_set_correctly(self, shots):
         """Test that the timeout attrbiute for the QuantumComputer stored by the QVMDevice
         is set correctly when passing a value as keyword argument"""
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev = plf.QVMDevice(device=device, shots=shots, timeout=100)
         assert dev.qc.compiler.client.timeout == 100
 
     def test_timeout_default(self, shots):
         """Test that the timeout attrbiute for the QuantumComputer stored by the QVMDevice
         is set to default when no specific value is being passed."""
-        device = np.random.choice(VALID_QPU_LATTICES)
+        device = np.random.choice(TEST_QPU_LATTICES)
         dev = plf.QVMDevice(device=device, shots=shots)
         qc = pyquil.get_qc(device, as_qvm=True)
 

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -30,9 +30,11 @@ class TestQPUIntegration(BaseTest):
 
     def test_load_qpu_device(self):
         """Test that the QPU device loads correctly"""
-        device = [qpu for qpu in VALID_QPU_LATTICES if "-2Q" in qpu][0]
+        device = VALID_QPU_LATTICES[0]
         dev = qml.device("forest.qpu", device=device, load_qc=False)
-        self.assertEqual(dev.num_wires, 2)
+        qc = pyquil.get_qc(device + "-qvm")
+        num_wires = len(qc.qubits())
+        self.assertEqual(dev.num_wires, num_wires)
         self.assertEqual(dev.shots, 1000)
         self.assertEqual(dev.short_name, "forest.qpu")
 

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -17,14 +17,9 @@ from flaky import flaky
 
 log = logging.getLogger(__name__)
 
-pattern = "Aspen-.-[1-5]Q-."
+pattern = "Aspen-."
 VALID_QPU_LATTICES = [
     qc for qc in pyquil.list_quantum_computers() if "qvm" not in qc and re.match(pattern, qc)
-]
-
-pattern_four_qubit = "Aspen-.-4Q-."
-VALID_FOUR_QUBIT_LATTICES = [
-    qc for qc in pyquil.list_quantum_computers() if "qvm" not in qc and re.match(pattern_four_qubit, qc)
 ]
 
 
@@ -72,7 +67,7 @@ class TestQPUIntegration(BaseTest):
 
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
-        device = np.random.choice(VALID_FOUR_QUBIT_LATTICES)
+        device = np.random.choice(VALID_QPU_LATTICES)
         p = np.pi / 8
         dev = qml.device(
             "forest.qpu",
@@ -119,7 +114,7 @@ class TestQPUIntegration(BaseTest):
 
         As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
-        device = np.random.choice(VALID_FOUR_QUBIT_LATTICES)
+        device = np.random.choice(VALID_QPU_LATTICES)
         p = np.pi / 7
         dev = qml.device(
             "forest.qpu",

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -28,11 +28,7 @@ from flaky import flaky
 
 log = logging.getLogger(__name__)
 
-# Creating pattern for devices that have at most 5 qubits
-pattern = "Aspen-."
-VALID_QPU_LATTICES = [
-    qc for qc in pyquil.list_quantum_computers() if "qvm" not in qc and re.match(pattern, qc)
-]
+TEST_QPU_LATTICES = ["4q-qvm"]
 
 
 compiled_program = (
@@ -475,14 +471,14 @@ class TestQVMBasic(BaseTest):
         with pytest.raises(ValueError, match="QVM device cannot be run in analytic=True mode."):
             dev = plf.QVMDevice(device="2q-qvm", shots=shots, analytic=True)
 
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_timeout_set_correctly(self, shots, device):
         """Test that the timeout attrbiute for the QuantumComputer stored by the QVMDevice
         is set correctly when passing a value as keyword argument"""
         dev = plf.QVMDevice(device=device, shots=shots, timeout=100)
         assert dev.qc.compiler.client.timeout == 100
 
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_timeout_default(self, shots, device):
         """Test that the timeout attrbiute for the QuantumComputer stored by the QVMDevice
         is set correctly when passing a value as keyword argument"""
@@ -701,7 +697,7 @@ class TestQVMIntegration(BaseTest):
 
     def test_load_virtual_qpu_device(self, qvm):
         """Test that the QPU simulators load correctly"""
-        qml.device("forest.qvm", device=np.random.choice(VALID_QPU_LATTICES))
+        qml.device("forest.qvm", device=np.random.choice(TEST_QPU_LATTICES))
 
     def test_qvm_args(self):
         """Test that the QVM plugin requires correct arguments"""
@@ -737,7 +733,7 @@ class TestQVMIntegration(BaseTest):
         )
 
     @flaky(max_runs=5, min_passes=2)
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_one_qubit_wavefunction_circuit(self, device, qvm, compiler):
         """Test that the wavefunction plugin provides correct result for simple circuit.
 
@@ -761,7 +757,7 @@ class TestQVMIntegration(BaseTest):
         self.assertAlmostEqual(circuit(a, b, c), np.cos(a) * np.sin(b), delta=3 / np.sqrt(shots))
 
     @flaky(max_runs=5, min_passes=3)
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_2q_gate(self, device, qvm, compiler):
         """Test that the two qubit gate with the PauliZ observable works correctly.
 
@@ -778,7 +774,7 @@ class TestQVMIntegration(BaseTest):
         assert np.allclose(circuit(), 0.0, atol=2e-2)
 
     @flaky(max_runs=5, min_passes=3)
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_2q_gate_pauliz_identity_tensor(self, device, qvm, compiler):
         """Test that the PauliZ tensor Identity observable works correctly.
 
@@ -795,7 +791,7 @@ class TestQVMIntegration(BaseTest):
         assert np.allclose(circuit(), 0.0, atol=2e-2)
 
     @flaky(max_runs=5, min_passes=3)
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_2q_gate_pauliz_pauliz_tensor(self, device, qvm, compiler):
         """Test that the PauliZ tensor PauliZ observable works correctly.
 
@@ -811,7 +807,7 @@ class TestQVMIntegration(BaseTest):
 
         assert np.allclose(circuit(), 1.0, atol=2e-2)
 
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_compiled_program_was_stored(self, qvm, device):
         """Test that QVM device stores the compiled program correctly"""
         dev = qml.device("forest.qvm", device=device, timeout=100)
@@ -842,7 +838,7 @@ class TestQVMIntegration(BaseTest):
             [False, False, False, False, False, False],
         ],
     )
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_compiled_program_was_stored_mutable_qnode_with_if_statement(
         self, qvm, device, statements
     ):
@@ -873,7 +869,7 @@ class TestQVMIntegration(BaseTest):
         length = 1 if (number_of_true == 6 or number_of_true == 0) else 2
         assert len(dev._compiled_program_dict.items()) == length
 
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_compiled_program_was_stored_mutable_qnode_with_loop(self, qvm, device):
         """Test that QVM device stores the compiled program when the QNode is
         mutated correctly"""
@@ -897,7 +893,7 @@ class TestQVMIntegration(BaseTest):
 
         assert len(dev._compiled_program_dict.items()) == len(qnodes)
 
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_compiled_program_was_used(self, qvm, device, monkeypatch):
         """Test that QVM device used the compiled program correctly, after it was stored"""
         dev = qml.device("forest.qvm", device=device, timeout=100)
@@ -928,7 +924,7 @@ class TestQVMIntegration(BaseTest):
         assert len(dev._compiled_program_dict.items()) == 1
 
     @flaky(max_runs=5, min_passes=1)
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_compiled_program_was_correct_compared_with_default_qubit(self, qvm, device, tol):
         """Test that QVM device stores the compiled program correctly by comparing it with default.qubit.
 
@@ -955,7 +951,7 @@ class TestQVMIntegration(BaseTest):
         assert len(dev._compiled_program_dict.items()) == 1
 
     @flaky(max_runs=5, min_passes=3)
-    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
+    @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(TEST_QPU_LATTICES)])
     def test_2q_gate_pauliz_pauliz_tensor_parametric_compilation_off(self, device, qvm, compiler):
         """Test that the PauliZ tensor PauliZ observable works correctly, when parametric compilation
         was turned off.

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -29,7 +29,7 @@ from flaky import flaky
 log = logging.getLogger(__name__)
 
 # Creating pattern for devices that have at most 5 qubits
-pattern = "Aspen-.-[1-5]Q-."
+pattern = "Aspen-."
 VALID_QPU_LATTICES = [
     qc for qc in pyquil.list_quantum_computers() if "qvm" not in qc and re.match(pattern, qc)
 ]
@@ -475,14 +475,6 @@ class TestQVMBasic(BaseTest):
         with pytest.raises(ValueError, match="QVM device cannot be run in analytic=True mode."):
             dev = plf.QVMDevice(device="2q-qvm", shots=shots, analytic=True)
 
-    def test_raise_error_if_qubits_not_indicated(self, shots):
-        """Test that instantiating a QVMDevice if the number of qubits were not indicated
-        in the name raises an error"""
-        with pytest.raises(
-            ValueError, match="QVM device string does not indicate the number of qubits!"
-        ):
-            dev = plf.QVMDevice(device="-qvm", shots=shots)
-
     @pytest.mark.parametrize("device", ["2q-qvm", np.random.choice(VALID_QPU_LATTICES)])
     def test_timeout_set_correctly(self, shots, device):
         """Test that the timeout attrbiute for the QuantumComputer stored by the QVMDevice
@@ -711,18 +703,6 @@ class TestQVMIntegration(BaseTest):
         """Test that the QPU simulators load correctly"""
         qml.device("forest.qvm", device=np.random.choice(VALID_QPU_LATTICES))
 
-    def test_incorrect_qc_name(self):
-        """Test that exception is raised if name is incorrect"""
-        with pytest.raises(
-            ValueError, match="QVM device string does not indicate the number of qubits"
-        ):
-            qml.device("forest.qvm", device="Aspen-1-B")
-
-    def test_incorrect_qc_type(self):
-        """Test that exception is raised device is not a string or graph"""
-        with pytest.raises(ValueError, match="Required argument device must be a string"):
-            qml.device("forest.qvm", device=3)
-
     def test_qvm_args(self):
         """Test that the QVM plugin requires correct arguments"""
         with pytest.raises(TypeError, match="missing 1 required positional argument"):
@@ -884,7 +864,6 @@ class TestQVMIntegration(BaseTest):
         for idx, stmt in enumerate(statements):
             qnodes[idx]([], statement=stmt)
             assert dev.circuit_hash in dev._compiled_program_dict
-            print(dev.circuit_hash, dev._compiled_program_dict)
 
         # Using that True evaluates to 1
         number_of_true = sum(statements)


### PR DESCRIPTION
Recent server-side changes on QCS have removed lattice-based devices such as `Aspen-4-5Q-E` and replaced with the full device, simply `Aspen-4`.

This is a breaking change in PL-Forest, which uses the lattice specification to load the number of qubits.

This PR fixes the issue: users can now load a device with
`dev = qml.device("forest.qvm", device="Aspen-4", shots=100)`