### PR TITLE
Flat tensor wires

### DIFF
--- a/pennylane_forest/qpu.py
+++ b/pennylane_forest/qpu.py
@@ -183,7 +183,7 @@ class QPUDevice(QVMDevice):
                 # the product of PauliZ operators on those qubits
                 pauli_obs = sI()
                 for wire in observable.wires:
-                    qubit = wire[0]
+                    qubit = wire
                     pauli_obs *= sZ(self.wiring[qubit])
 
 
@@ -202,10 +202,7 @@ class QPUDevice(QVMDevice):
 
             if self.readout_error is not None:
                 for wire in observable.wires:
-                    if isinstance(wire, int):
-                        qubit = wire
-                    elif isinstance(wire, List):
-                        qubit = wire[0]
+                    qubit = wire
                     prep_prog.define_noisy_readout(
                         self.wiring[qubit], p00=self.readout_error[0], p11=self.readout_error[1]
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16
-pennylane>=0.9
+git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
 networkx
 flaky

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pyquil>=2.16
-git+https://github.com/XanaduAI/pennylane.git#egg=pennylane
+pennylane>=0.10
 networkx
 flaky

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -60,7 +60,7 @@ class TestQPUIntegration(BaseTest):
     @pytest.mark.parametrize(
         "obs", [qml.PauliX(0), qml.PauliZ(0), qml.PauliY(0), qml.Hadamard(0), qml.Identity(0)]
     )
-    def test_tensor_wires_expval_parametric_compilation(self, obs):
+    def test_tensor_expval_parametric_compilation(self, obs):
         """Test the QPU expval method for Tensor observables made up of a single observable when parametric compilation is
         turned on.
 
@@ -107,7 +107,7 @@ class TestQPUIntegration(BaseTest):
     @pytest.mark.parametrize(
         "obs", [qml.PauliX(0), qml.PauliZ(0), qml.PauliY(0), qml.Hadamard(0), qml.Identity(0)]
     )
-    def test_tensor_wires_expval_operator_estimation(self, obs):
+    def test_tensor_expval_operator_estimation(self, obs):
         """Test the QPU expval method for Tensor observables made up of a single observable when parametric compilation is
         turned off allowing operator estimation.
 

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -366,7 +366,7 @@ class TestQPUBasic(BaseTest):
 
         result = circuit()
 
-        assert np.isclose(result, 0.5, atol=2e-2)
+        assert np.isclose(result, 0.5, atol=3e-2)
 
     @flaky(max_runs=5, min_passes=3)
     def test_2q_gate(self):

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -372,7 +372,8 @@ class TestQPUBasic(BaseTest):
     def test_2q_gate(self):
         """Test that the two qubit gate with the PauliZ observable works correctly.
 
-        As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
+        As the results coming from the qvm are stochastic, a constraint of 3
+        out of 5 runs was added.
         """
 
         device = np.random.choice(TEST_QPU_LATTICES)

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -372,8 +372,7 @@ class TestQPUBasic(BaseTest):
     def test_2q_gate(self):
         """Test that the two qubit gate with the PauliZ observable works correctly.
 
-        As the results coming from the qvm are stochastic, a constraint of 3
-        out of 5 runs was added.
+        As the results coming from the qvm are stochastic, a constraint of 3 out of 5 runs was added.
         """
 
         device = np.random.choice(TEST_QPU_LATTICES)


### PR DESCRIPTION
Two changes are included:
* A change to how wires are handled for the `Tensor` class, as PennyLane core now stores a flat sequence of wires (as opposed to the previous nested sequence)
* The requirement of PennyLane was changed to the latest master version. This is useful to check that all are fine before the release.

The second change *will have to be reverted* right before the actual release (with the version bump)