### PR TITLE
Fix bug in basis_state()

### DIFF
--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -40,7 +40,7 @@ from pyquil.api._base_connection import ForestConnection
 from pyquil.api._config import PyquilConfig
 
 from pyquil.quil import DefGate
-from pyquil.gates import X, Y, Z, H, PHASE, RX, RY, RZ, CZ, SWAP, CNOT, S, T, CSWAP
+from pyquil.gates import X, Y, Z, H, PHASE, RX, RY, RZ, CZ, SWAP, CNOT, S, T, CSWAP, I
 
 # following gates are not supported by PennyLane
 from pyquil.gates import CPHASE00, CPHASE01, CPHASE10, CPHASE, CCNOT, ISWAP, PSWAP
@@ -66,7 +66,8 @@ def basis_state(par, *wires):
         list: list of PauliX matrix operators acting on each wire
     """
     # pylint: disable=unused-argument
-    return [X(w) for w, p in zip(wires, par) if p == 1]
+    # need the identity here because otherwise only the "p=1" wires register in the circuit
+    return [X(w) if p == 1 else I(w) for w, p in zip(wires, par)]
 
 
 def qubit_unitary(par, *wires):


### PR DESCRIPTION
Our new shared device test suite uncovered a bug that this PR fixes:

The wavefunction device is aware of the "active wires" in a circuit, and only creates a state large enough for them. The failing test applies ``BasisState`` with inputs like ``[1, 1, 0, 0]``. The device only queues two `X` gates and registers 2 active wires (and a 2^2 dimensional state gets created). But the active wires extracted from the PennyLane operation are 4, because BasisState acts on all 4 wires.

The fix just adds dummy Identities to the queue.