### PR TITLE
Using device wires analytic_probability method

### DIFF
--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -361,7 +361,7 @@ class ForestDevice(QubitDevice):
         if self._state is None:
             return None
 
-        wires = wires or range(self.num_wires)
+        wires = wires or self.wires
         wires = Wires(wires)
         prob = self.marginal_prob(np.abs(self._state) ** 2, wires)
         return prob

--- a/tests/test_qpu.py
+++ b/tests/test_qpu.py
@@ -118,14 +118,14 @@ class TestQPUIntegration(BaseTest):
         dev = qml.device(
             "forest.qpu",
             device=device,
-            shots=1000,
+            shots=2000,
             load_qc=False,
             parametric_compilation=False,
         )
         dev_1 = qml.device(
             "forest.qpu",
             device=device,
-            shots=1000,
+            shots=2000,
             load_qc=False,
             parametric_compilation=False,
         )


### PR DESCRIPTION
Changes to using the custom device wires if no `wires` argument was specified instead of using scalar indices in the `analytic_probability` method