### PR TITLE
Delete superfluous wires conversion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,11 +9,17 @@ PennyLane Forest Plugin
     :alt: Documentation Status
     :target: http://pennylane-forest.readthedocs.io/en/latest/?badge=latest
 
-Contains the PennyLane Forest plugin. This plugin allows three Rigetti devices to work with PennyLane --- the wavefunction simulator, the Quantum Virtual Machine (QVM), and Quantum Processing Units (QPUs).
+Contains the PennyLane Forest plugin. This plugin allows three Rigetti devices to work with
+PennyLane --- the wavefunction simulator, the Quantum Virtual Machine (QVM), and Quantum Processing
+Units (QPUs).
 
-`pyQuil <https://pyquil.readthedocs.io>`_ is a Python library for quantum programming using the quantum instruction language (Quil) --- resulting quantum programs can be executed using the `Rigetti Forest SDK <https://www.rigetti.com/forest>`_ and the `Rigetti QCS <https://www.rigetti.com/qcs>`_.
+`pyQuil <https://pyquil.readthedocs.io>`_ is a Python library for quantum programming using the
+quantum instruction language (Quil) --- resulting quantum programs can be executed using the
+`Rigetti Forest SDK <https://www.rigetti.com/forest>`_ and the `Rigetti QCS
+<https://www.rigetti.com/qcs>`_.
 
-`PennyLane <https://pennylane.ai>`_ is a machine learning library for optimization and automatic differentiation of hybrid quantum-classical computations.
+`PennyLane <https://pennylane.ai>`_ is a machine learning library for optimization and automatic
+differentiation of hybrid quantum-classical computations.
 
 
 Features

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Contains the PennyLane Forest plugin. This plugin allows three Rigetti devices t
 
 `pyQuil <https://pyquil.readthedocs.io>`_ is a Python library for quantum programming using the quantum instruction language (Quil) --- resulting quantum programs can be executed using the `Rigetti Forest SDK <https://www.rigetti.com/forest>`_ and the `Rigetti QCS <https://www.rigetti.com/qcs>`_.
 
-`PennyLane <https://pennylane.readthedocs.io>`_ is a machine learning library for optimization and automatic differentiation of hybrid quantum-classical computations.
+`PennyLane <https://pennylane.ai>`_ is a machine learning library for optimization and automatic differentiation of hybrid quantum-classical computations.
 
 
 Features

--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -361,7 +361,5 @@ class ForestDevice(QubitDevice):
         if self._state is None:
             return None
 
-        wires = wires or range(self.num_wires)
-        wires = Wires(wires)
         prob = self.marginal_prob(np.abs(self._state) ** 2, wires)
         return prob


### PR DESCRIPTION
This PR fixes a failing test in the shared device test suite by deleting a wrong wire conversion that was actually not required in the first place.