### PR TITLE
Adapt hardware devices to process custom wires

### DIFF
--- a/pennylane_forest/device.py
+++ b/pennylane_forest/device.py
@@ -361,7 +361,5 @@ class ForestDevice(QubitDevice):
         if self._state is None:
             return None
 
-        wires = wires or range(self.num_wires)
-        wires = Wires(wires)
         prob = self.marginal_prob(np.abs(self._state) ** 2, wires)
         return prob

--- a/pennylane_forest/numpy_wavefunction.py
+++ b/pennylane_forest/numpy_wavefunction.py
@@ -34,7 +34,9 @@ class NumpyWavefunctionDevice(ForestDevice):
     r"""NumpyWavefunction simulator device for PennyLane.
 
     Args:
-        wires (int): the number of qubits to initialize the device in
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``).
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables.
     """

--- a/pennylane_forest/wavefunction.py
+++ b/pennylane_forest/wavefunction.py
@@ -52,7 +52,9 @@ class WavefunctionDevice(ForestDevice):
     r"""Wavefunction simulator device for PennyLane.
 
     Args:
-        wires (int): the number of qubits to initialize the device in
+        wires (int or Iterable[Number, str]]): Number of subsystems represented by the device,
+            or iterable that contains unique labels for the subsystems as numbers (i.e., ``[-1, 0, 2]``)
+            or strings (``['ancilla', 'q1', 'q2']``).
         shots (int): Number of circuit evaluations/random samples used
             to estimate expectation values of observables.
 

--- a/tests/test_qvm.py
+++ b/tests/test_qvm.py
@@ -13,6 +13,7 @@ from pennylane import numpy as np
 from pennylane.operation import Tensor
 from pennylane.circuit_graph import CircuitGraph
 from pennylane.variable import Variable
+from pennylane.wires import Wires
 
 from pyquil.quil import Pragma, Program
 from pyquil.api._quantum_computer import QuantumComputer
@@ -464,6 +465,21 @@ class TestQVMBasic(BaseTest):
             + 6
         ) / 32
         assert np.allclose(np.mean(s1), expected, atol=0.1, rtol=0)
+
+    def test_wires_argument(self):
+        """Test that the wires argument gets processed correctly."""
+
+        dev_no_wires = plf.QVMDevice(device="2q-qvm", shots=5)
+        assert dev_no_wires.wires == Wires(range(2))
+
+        with pytest.raises(ValueError, match="Device has a fixed number of"):
+            plf.QVMDevice(device="2q-qvm", shots=5, wires=1000)
+
+        dev_iterable_wires = plf.QVMDevice(device="2q-qvm", shots=5, wires=range(2))
+        assert dev_iterable_wires.wires == Wires(range(2))
+
+        with pytest.raises(ValueError, match="Device has a fixed number of"):
+            plf.QVMDevice(device="2q-qvm", shots=5, wires=range(1000))
 
     @pytest.mark.parametrize("shots", list(range(0, -10, -1)))
     def test_raise_error_if_shots_is_not_positive(self, shots):


### PR DESCRIPTION
In the previous wires refactor (PR #55) we didn't include the hardware devices, which do not take a wires argument at all. But it would be nice if they could be addressed with custom wire labels. 

This PR adds an optional kwarg ``wires`` which can be an iterable of the length ``num_wires`` (which is the inferred number of wires on the device).

Note, this PR branches of PR #58 to avoid the tests failing.